### PR TITLE
feat: add CORS configuration

### DIFF
--- a/cmd/aegisflow/main.go
+++ b/cmd/aegisflow/main.go
@@ -207,6 +207,7 @@ func main() {
 	// In production, ensure only your reverse proxy (nginx, ALB, etc.) sets these.
 	r.Use(chimw.RealIP)
 	r.Use(chimw.Recoverer)
+	r.Use(middleware.CORS(cfg))
 	r.Use(middleware.Auth(cfg))
 	r.Use(middleware.RateLimit(limiter))
 	r.Use(middleware.TokenRateLimit(tokenLimiter))

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/aegisflow/aegisflow/internal/cache"
 	"github.com/aegisflow/aegisflow/internal/config"
+	"github.com/aegisflow/aegisflow/internal/middleware"
 	"github.com/aegisflow/aegisflow/internal/provider"
 	"github.com/aegisflow/aegisflow/internal/usage"
 )
@@ -68,6 +69,7 @@ func NewServer(tracker *usage.Tracker, cfg *config.Config, registry *provider.Re
 func (s *Server) Router() http.Handler {
 	r := chi.NewRouter()
 	r.Use(chimw.Recoverer)
+	r.Use(middleware.CORS(s.cfg))
 
 	r.Get("/health", s.healthHandler)
 	r.Get("/metrics", promhttp.Handler().ServeHTTP)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,6 +114,17 @@ type ServerConfig struct {
 	ReadTimeout      time.Duration `yaml:"read_timeout"`
 	WriteTimeout     time.Duration `yaml:"write_timeout"`
 	GracefulShutdown time.Duration `yaml:"graceful_shutdown"`
+	CORS             CORSConfig    `yaml:"cors"`
+}
+
+type CORSConfig struct {
+	Enabled          bool     `yaml:"enabled"`
+	AllowedOrigins   []string `yaml:"allowed_origins"`
+	AllowedMethods   []string `yaml:"allowed_methods"`
+	AllowedHeaders   []string `yaml:"allowed_headers"`
+	ExposedHeaders   []string `yaml:"exposed_headers"`
+	AllowCredentials bool     `yaml:"allow_credentials"`
+	MaxAge           int      `yaml:"max_age"`
 }
 
 type ProviderConfig struct {
@@ -309,6 +320,22 @@ func setDefaults(cfg *Config) {
 	}
 	if cfg.Budgets.Global.WarnAt == 0 {
 		cfg.Budgets.Global.WarnAt = 90
+	}
+
+	// CORS defaults
+	if cfg.Server.CORS.Enabled {
+		if len(cfg.Server.CORS.AllowedOrigins) == 0 {
+			cfg.Server.CORS.AllowedOrigins = []string{"*"}
+		}
+		if len(cfg.Server.CORS.AllowedMethods) == 0 {
+			cfg.Server.CORS.AllowedMethods = []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"}
+		}
+		if len(cfg.Server.CORS.AllowedHeaders) == 0 {
+			cfg.Server.CORS.AllowedHeaders = []string{"Authorization", "Content-Type", "X-API-Key"}
+		}
+		if cfg.Server.CORS.MaxAge == 0 {
+			cfg.Server.CORS.MaxAge = 86400
+		}
 	}
 }
 

--- a/internal/middleware/cors.go
+++ b/internal/middleware/cors.go
@@ -1,0 +1,54 @@
+package middleware
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/aegisflow/aegisflow/internal/config"
+)
+
+func CORS(cfg *config.Config) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !cfg.Server.CORS.Enabled {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			origin := r.Header.Get("Origin")
+			if origin == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			allowed := false
+			for _, o := range cfg.Server.CORS.AllowedOrigins {
+				if o == "*" || o == origin {
+					allowed = true
+					break
+				}
+			}
+
+			if allowed {
+				w.Header().Set("Access-Control-Allow-Origin", origin)
+				if cfg.Server.CORS.AllowCredentials {
+					w.Header().Set("Access-Control-Allow-Credentials", "true")
+				}
+				if len(cfg.Server.CORS.ExposedHeaders) > 0 {
+					w.Header().Set("Access-Control-Expose-Headers", strings.Join(cfg.Server.CORS.ExposedHeaders, ", "))
+				}
+
+				if r.Method == http.MethodOptions {
+					w.Header().Set("Access-Control-Allow-Methods", strings.Join(cfg.Server.CORS.AllowedMethods, ", "))
+					w.Header().Set("Access-Control-Allow-Headers", strings.Join(cfg.Server.CORS.AllowedHeaders, ", "))
+					w.Header().Set("Access-Control-Max-Age", strconv.Itoa(cfg.Server.CORS.MaxAge))
+					w.WriteHeader(http.StatusNoContent)
+					return
+				}
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds CORS configuration to the server and admin API.

Changes:
- Added `CORSConfig` to `ServerConfig` in `internal/config/config.go`.
- Implemented CORS middleware in `internal/middleware/cors.go`.
- Applied CORS middleware to the gateway and admin routers.

Fixes #31