### PR TITLE
Add max_body_size server config

### DIFF
--- a/cmd/aegisflow/main.go
+++ b/cmd/aegisflow/main.go
@@ -1,12 +1,12 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"flag"
 	"fmt"
 	"log"
 	"net/http"
-	"bufio"
 	"os"
 	"os/signal"
 	"strings"
@@ -186,7 +186,7 @@ func main() {
 		recordSpendFn = budgetMgr.RecordSpend
 		budgetCheckFn = budgetMgr.CheckFunc()
 	}
-	handler := gateway.NewHandler(registry, rt, pe, ut, responseCache, wh, pgStore, analyticsCollector, recordSpendFn, budgetCheckFn)
+	handler := gateway.NewHandler(registry, rt, pe, ut, responseCache, wh, pgStore, analyticsCollector, cfg.Server.MaxBodySize, recordSpendFn, budgetCheckFn)
 
 	// Rate limiter
 	// Use the highest tenant rate limit as the global limiter cap

--- a/configs/aegisflow.example.yaml
+++ b/configs/aegisflow.example.yaml
@@ -9,6 +9,7 @@ server:
   read_timeout: 30s             # HTTP read timeout
   write_timeout: 120s           # HTTP write timeout (long for streaming)
   graceful_shutdown: 10s        # Graceful shutdown timeout
+  max_body_size: 10485760       # Max request body size in bytes (10MB)
 
 # Provider definitions
 # Each provider needs a unique name and a type.

--- a/configs/aegisflow.yaml
+++ b/configs/aegisflow.yaml
@@ -5,6 +5,7 @@ server:
   read_timeout: 30s
   write_timeout: 120s
   graceful_shutdown: 10s
+  max_body_size: 10485760
 
 providers:
   - name: "mock"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,30 +11,30 @@ import (
 )
 
 type Config struct {
-	Server    ServerConfig    `yaml:"server"`
+	Server    ServerConfig     `yaml:"server"`
 	Providers []ProviderConfig `yaml:"providers"`
-	Routes    []RouteConfig   `yaml:"routes"`
-	Tenants   []TenantConfig  `yaml:"tenants"`
-	RateLimit RateLimitConfig `yaml:"rate_limit"`
-	Policies  PoliciesConfig  `yaml:"policies"`
-	Telemetry TelemetryConfig `yaml:"telemetry"`
-	Logging   LoggingConfig   `yaml:"logging"`
-	Cache     CacheConfig     `yaml:"cache"`
-	Webhook   WebhookConfig   `yaml:"webhook"`
-	Database  DatabaseConfig  `yaml:"database"`
-	Admin     AdminConfig     `yaml:"admin"`
-	Aliases   AliasConfig     `yaml:"aliases"`
-	Transform TransformConfig `yaml:"transform"`
-	Analytics AnalyticsConfig `yaml:"analytics"`
-	Budgets   BudgetsConfig   `yaml:"budgets"`
+	Routes    []RouteConfig    `yaml:"routes"`
+	Tenants   []TenantConfig   `yaml:"tenants"`
+	RateLimit RateLimitConfig  `yaml:"rate_limit"`
+	Policies  PoliciesConfig   `yaml:"policies"`
+	Telemetry TelemetryConfig  `yaml:"telemetry"`
+	Logging   LoggingConfig    `yaml:"logging"`
+	Cache     CacheConfig      `yaml:"cache"`
+	Webhook   WebhookConfig    `yaml:"webhook"`
+	Database  DatabaseConfig   `yaml:"database"`
+	Admin     AdminConfig      `yaml:"admin"`
+	Aliases   AliasConfig      `yaml:"aliases"`
+	Transform TransformConfig  `yaml:"transform"`
+	Analytics AnalyticsConfig  `yaml:"analytics"`
+	Budgets   BudgetsConfig    `yaml:"budgets"`
 }
 
 type CacheConfig struct {
-	Enabled  bool          `yaml:"enabled"`
-	Backend  string        `yaml:"backend"`
-	TTL      time.Duration `yaml:"ttl"`
-	MaxSize  int           `yaml:"max_size"`
-	Redis    RedisConfig   `yaml:"redis"`
+	Enabled bool          `yaml:"enabled"`
+	Backend string        `yaml:"backend"`
+	TTL     time.Duration `yaml:"ttl"`
+	MaxSize int           `yaml:"max_size"`
+	Redis   RedisConfig   `yaml:"redis"`
 }
 
 type WebhookConfig struct {
@@ -114,6 +114,7 @@ type ServerConfig struct {
 	ReadTimeout      time.Duration `yaml:"read_timeout"`
 	WriteTimeout     time.Duration `yaml:"write_timeout"`
 	GracefulShutdown time.Duration `yaml:"graceful_shutdown"`
+	MaxBodySize      int64         `yaml:"max_body_size"`
 	CORS             CORSConfig    `yaml:"cors"`
 }
 
@@ -128,18 +129,18 @@ type CORSConfig struct {
 }
 
 type ProviderConfig struct {
-	Name      string            `yaml:"name"`
-	Type      string            `yaml:"type"`
-	Enabled   bool              `yaml:"enabled"`
-	Default   bool              `yaml:"default"`
-	BaseURL   string            `yaml:"base_url"`
-	APIKeyEnv string            `yaml:"api_key_env"`
-	Models    []string          `yaml:"models"`
-	Timeout   time.Duration     `yaml:"timeout"`
-	MaxRetries int              `yaml:"max_retries"`
-	APIVersion string           `yaml:"api_version"`
-	Config    map[string]string `yaml:"config"`
-	Region    string            `yaml:"region"`
+	Name       string            `yaml:"name"`
+	Type       string            `yaml:"type"`
+	Enabled    bool              `yaml:"enabled"`
+	Default    bool              `yaml:"default"`
+	BaseURL    string            `yaml:"base_url"`
+	APIKeyEnv  string            `yaml:"api_key_env"`
+	Models     []string          `yaml:"models"`
+	Timeout    time.Duration     `yaml:"timeout"`
+	MaxRetries int               `yaml:"max_retries"`
+	APIVersion string            `yaml:"api_version"`
+	Config     map[string]string `yaml:"config"`
+	Region     string            `yaml:"region"`
 }
 
 type RegionConfig struct {

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -32,14 +32,21 @@ type Handler struct {
 	store       *storage.PostgresStore
 	dbQueue     chan storage.UsageEvent
 	analytics   *analytics.Collector
+	maxBodySize int64
 	recordSpend func(tenantID, model string, cost float64)
 	budgetCheck func(tenantID, model string) (bool, []string, string)
 }
 
-const dbQueueSize = 1024
+const (
+	dbQueueSize        = 1024
+	defaultMaxBodySize = 10 * 1024 * 1024
+)
 
-func NewHandler(registry *provider.Registry, rt *router.Router, pe *policy.Engine, ut *usage.Tracker, c cache.Cache, wh *webhook.Notifier, store *storage.PostgresStore, ac *analytics.Collector, recordSpend func(string, string, float64), budgetCheck func(string, string) (bool, []string, string)) *Handler {
-	h := &Handler{registry: registry, router: rt, policy: pe, usage: ut, cache: c, webhook: wh, store: store, analytics: ac, recordSpend: recordSpend, budgetCheck: budgetCheck}
+func NewHandler(registry *provider.Registry, rt *router.Router, pe *policy.Engine, ut *usage.Tracker, c cache.Cache, wh *webhook.Notifier, store *storage.PostgresStore, ac *analytics.Collector, maxBodySize int64, recordSpend func(string, string, float64), budgetCheck func(string, string) (bool, []string, string)) *Handler {
+	if maxBodySize <= 0 {
+		maxBodySize = defaultMaxBodySize
+	}
+	h := &Handler{registry: registry, router: rt, policy: pe, usage: ut, cache: c, webhook: wh, store: store, analytics: ac, maxBodySize: maxBodySize, recordSpend: recordSpend, budgetCheck: budgetCheck}
 	if store != nil {
 		h.dbQueue = make(chan storage.UsageEvent, dbQueueSize)
 		go h.dbWorker()
@@ -66,9 +73,8 @@ func (h *Handler) Close() {
 
 func (h *Handler) ChatCompletion(w http.ResponseWriter, r *http.Request) {
 	startTime := time.Now()
-	const maxBodySize = 10 * 1024 * 1024 // 10MB
 	var req types.ChatCompletionRequest
-	if err := json.NewDecoder(io.LimitReader(r.Body, maxBodySize)).Decode(&req); err != nil {
+	if err := json.NewDecoder(io.LimitReader(r.Body, h.maxBodySize)).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid_request", "failed to parse request body")
 		return
 	}

--- a/internal/gateway/handler_test.go
+++ b/internal/gateway/handler_test.go
@@ -24,7 +24,7 @@ func setupTestHandler() *Handler {
 	rt := router.NewRouter(routes, registry)
 	pe := policy.NewEngine(nil, nil)
 	ut := usage.NewTracker(usage.NewStore())
-	return NewHandler(registry, rt, pe, ut, nil, nil, nil, nil, nil, nil)
+	return NewHandler(registry, rt, pe, ut, nil, nil, nil, nil, 0, nil, nil)
 }
 
 func TestChatCompletionSuccess(t *testing.T) {
@@ -155,4 +155,3 @@ func TestInvalidJSON(t *testing.T) {
 		t.Errorf("expected 400, got %d", w.Code)
 	}
 }
-


### PR DESCRIPTION
## What does this PR do?

Adds `server.max_body_size` to the config and uses it in the gateway request body limit. It also documents the setting in the sample config files.

## Related Issue

Closes #30

## Type of Change

- [x] Enhancement
- [x] Documentation

## Checklist

- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] My code follows the existing code style
- [ ] I have added tests for my changes
- [ ] All tests pass (`make test`)
- [x] I have updated documentation if needed

## Validation

- `go test ./internal/config ./internal/gateway`