### PR TITLE
Add development Docker hot-reload setup

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,14 @@
+root = "."
+tmp_dir = "tmp"
+
+[build]
+cmd = "go build -o ./tmp/aegisflow ./cmd/aegisflow"
+bin = "./tmp/aegisflow"
+full_bin = "./tmp/aegisflow --config configs/aegisflow.yaml"
+include_ext = ["go", "yaml", "yml", "html"]
+exclude_dir = ["tmp", "bin", "plugins", ".git"]
+delay = 500
+stop_on_error = true
+
+[screen]
+clear_on_rebuild = true

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,15 @@
+FROM golang:1.26-alpine
+
+RUN apk add --no-cache git ca-certificates build-base && \
+    go install github.com/air-verse/air@latest
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+EXPOSE 8080 8081
+
+CMD ["air", "-c", ".air.toml"]


### PR DESCRIPTION
## Summary
- add `Dockerfile.dev` based on the Go Alpine image for local development
- install `air` and wire it to rebuild `cmd/aegisflow` on source and config changes
- expose both gateway and admin ports so the development container matches the local runtime shape

## Why
The repository only shipped a production-oriented image. Development in Docker did not support hot reload, which made iteration slower than necessary.

## Validation
- reviewed the development image and Air configuration together to ensure the entrypoint rebuilds `cmd/aegisflow`
- attempted `docker build -f Dockerfile.dev -t aegisflow-dev:test .` locally, but the Docker daemon was not running in this environment

Closes #34
