### PR TITLE
Retry eval webhooks once on transient failures

### DIFF
--- a/internal/eval/webhook.go
+++ b/internal/eval/webhook.go
@@ -3,6 +3,7 @@ package eval
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"log"
 	"math/rand"
 	"net/http"
@@ -34,6 +35,8 @@ type WebhookEvaluator struct {
 	timeout         time.Duration
 	sendFullContent bool
 	client          *http.Client
+	retryDelay      time.Duration
+	sleep           func(time.Duration)
 }
 
 // NewWebhookEvaluator creates a WebhookEvaluator with the given configuration.
@@ -47,6 +50,8 @@ func NewWebhookEvaluator(url string, sampleRate float64, timeout time.Duration, 
 		timeout:         timeout,
 		sendFullContent: sendFullContent,
 		client:          &http.Client{Timeout: timeout},
+		retryDelay:      time.Second,
+		sleep:           time.Sleep,
 	}
 }
 
@@ -69,17 +74,37 @@ func (w *WebhookEvaluator) Evaluate(req WebhookRequest) {
 			log.Printf("eval webhook: marshal error: %v", err)
 			return
 		}
-		resp, err := w.client.Post(w.url, "application/json", bytes.NewReader(data))
-		if err != nil {
-			log.Printf("eval webhook: request error: %v", err)
+		for attempt := 0; attempt < 2; attempt++ {
+			resp, err := w.client.Post(w.url, "application/json", bytes.NewReader(data))
+			if err == nil {
+				if resp.StatusCode < 500 {
+					resp.Body.Close()
+					if resp.StatusCode >= 400 {
+						log.Printf("eval webhook: returned %d", resp.StatusCode)
+					}
+					return
+				}
+				log.Printf("eval webhook: returned %d", resp.StatusCode)
+				resp.Body.Close()
+			} else {
+				log.Printf("eval webhook: request error: %v", err)
+				if !shouldRetryWebhook(err) {
+					return
+				}
+			}
+
+			if attempt == 0 {
+				w.sleep(w.retryDelay)
+				continue
+			}
 			return
 		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode >= 400 {
-			log.Printf("eval webhook: returned %d", resp.StatusCode)
-		}
 	}()
+}
+
+func shouldRetryWebhook(err error) bool {
+	var netErr interface{ Timeout() bool }
+	return errors.As(err, &netErr) && netErr.Timeout()
 }
 
 func truncate(s string, maxRunes int) string {

--- a/internal/eval/webhook_retry_test.go
+++ b/internal/eval/webhook_retry_test.go
@@ -1,0 +1,68 @@
+package eval
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestEvaluateRetriesOnceOn5xx(t *testing.T) {
+	var attempts atomic.Int32
+	received := make(chan struct{}, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received <- struct{}{}
+		if attempts.Add(1) == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	we := NewWebhookEvaluator(server.URL, 1.0, 200*time.Millisecond, true)
+	we.retryDelay = 5 * time.Millisecond
+	we.Evaluate(WebhookRequest{Prompt: "hello", Response: "world"})
+
+	timeout := time.After(500 * time.Millisecond)
+	count := 0
+	for count < 2 {
+		select {
+		case <-received:
+			count++
+		case <-timeout:
+			t.Fatalf("expected 2 attempts, got %d", count)
+		}
+	}
+}
+
+func TestEvaluateRetriesOnceOnTimeout(t *testing.T) {
+	var attempts atomic.Int32
+	received := make(chan struct{}, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received <- struct{}{}
+		if attempts.Add(1) == 1 {
+			time.Sleep(30 * time.Millisecond)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	we := NewWebhookEvaluator(server.URL, 1.0, 10*time.Millisecond, true)
+	we.retryDelay = 5 * time.Millisecond
+	we.Evaluate(WebhookRequest{Prompt: "hello", Response: "world"})
+
+	timeout := time.After(500 * time.Millisecond)
+	count := 0
+	for count < 2 {
+		select {
+		case <-received:
+			count++
+		case <-timeout:
+			t.Fatalf("expected 2 attempts, got %d", count)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- retry eval webhook deliveries once when the endpoint returns a 5xx response
- retry once when the webhook request times out
- add focused tests for both retry paths

## Why
The evaluator previously gave up after a single transient failure, which made webhook delivery less reliable than necessary for temporary upstream issues.

## Validation
- `go test ./internal/eval`

Closes #50
