### PR TITLE
Add aegisctl federation status command

### DIFF
--- a/cmd/aegisctl/main.go
+++ b/cmd/aegisctl/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io"
 	"net/http"
@@ -28,6 +29,23 @@ func main() {
 	gatewayURL := getEnv("AEGISFLOW_GATEWAY_URL", defaultGatewayURL)
 
 	switch os.Args[1] {
+	case "federation":
+		if len(os.Args) < 3 {
+			fmt.Println("Usage: aegisctl federation <status> [args]")
+			os.Exit(1)
+		}
+		var err error
+		switch os.Args[2] {
+		case "status":
+			err = cmdFederationStatus(os.Args[3:], adminURL)
+		default:
+			fmt.Printf("Unknown federation command: %s\n", os.Args[2])
+			os.Exit(1)
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
 	case "plugin":
 		if len(os.Args) < 3 {
 			fmt.Println("Usage: aegisctl plugin <search|info|install|list|remove> [args]")
@@ -90,6 +108,7 @@ func printUsage() {
 Usage: aegisctl <command> [args]
 
 Commands:
+  federation  Federation commands (status)
   plugin      Manage WASM plugins (search, info, install, list, remove)
   status      Check gateway and admin health
   usage       Show usage per tenant and model
@@ -335,6 +354,51 @@ func cmdTest(gatewayURL, apiKey, model, message string) {
 	fmt.Printf("Latency:  %s\n", latency.Round(time.Millisecond))
 	fmt.Printf("Tokens:   %d\n", result.Usage.TotalTokens)
 	fmt.Printf("Response: %s\n", result.Choices[0].Message.Content)
+}
+
+func cmdFederationStatus(args []string, adminURL string) error {
+	fs := flag.NewFlagSet("federation status", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	url := fs.String("url", adminURL, "admin URL")
+	if err := fs.Parse(args); err != nil {
+		return fmt.Errorf("usage: aegisctl federation status --url %s", adminURL)
+	}
+
+	resp, err := client.Get(strings.TrimRight(*url, "/") + "/admin/v1/federation/planes")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("admin API returned %d", resp.StatusCode)
+	}
+
+	var planes []struct {
+		Name     string    `json:"name"`
+		Healthy  bool      `json:"healthy"`
+		LastSeen time.Time `json:"last_seen"`
+		Requests int64     `json:"requests"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&planes); err != nil {
+		return err
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "NAME\tHEALTH\tLAST SEEN\tREQUESTS")
+	fmt.Fprintln(w, "────\t──────\t─────────\t────────")
+	for _, plane := range planes {
+		health := "unhealthy"
+		if plane.Healthy {
+			health = "healthy"
+		}
+		lastSeen := "--"
+		if !plane.LastSeen.IsZero() {
+			lastSeen = plane.LastSeen.Local().Format(time.RFC3339)
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%d\n", plane.Name, health, lastSeen, plane.Requests)
+	}
+	w.Flush()
+	return nil
 }
 
 func checkHealth(url string) bool {

--- a/cmd/aegisctl/main_test.go
+++ b/cmd/aegisctl/main_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	defer func() {
+		os.Stdout = old
+	}()
+
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+
+	fn()
+	_ = w.Close()
+	return <-done
+}
+
+func TestCmdFederationStatus(t *testing.T) {
+	oldClient := client
+	defer func() { client = oldClient }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/admin/v1/federation/planes" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"name":"us-east","healthy":true,"last_seen":"2026-04-02T17:00:00Z","requests":42}]`))
+	}))
+	defer server.Close()
+
+	client = server.Client()
+	out := captureStdout(t, func() {
+		if err := cmdFederationStatus([]string{"--url", server.URL}, defaultAdminURL); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	if !strings.Contains(out, "us-east") || !strings.Contains(out, "healthy") || !strings.Contains(out, "42") {
+		t.Fatalf("unexpected output: %s", out)
+	}
+}
+
+func TestCmdFederationStatusEmpty(t *testing.T) {
+	oldClient := client
+	defer func() { client = oldClient }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	client = server.Client()
+	out := captureStdout(t, func() {
+		if err := cmdFederationStatus([]string{"--url", server.URL}, defaultAdminURL); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	if !strings.Contains(out, "NAME") {
+		t.Fatalf("expected table header, got %s", out)
+	}
+}
+
+func TestCmdFederationStatusFormatsZeroTime(t *testing.T) {
+	oldClient := client
+	defer func() { client = oldClient }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]map[string]any{{
+			"name": "plane-a", "healthy": false, "last_seen": time.Time{}, "requests": 0,
+		}})
+	}))
+	defer server.Close()
+
+	client = server.Client()
+	out := captureStdout(t, func() {
+		if err := cmdFederationStatus([]string{"--url", server.URL}, defaultAdminURL); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if !strings.Contains(out, "--") {
+		t.Fatalf("expected zero time placeholder, got %s", out)
+	}
+}


### PR DESCRIPTION
## Summary
- add an `aegisctl federation status` subcommand that reads `/admin/v1/federation/planes`
- render plane health, last-seen time, and request counts in a table
- add CLI tests for populated, empty, and zero-time responses

## Why
The control plane exposed federation status through the admin API, but there was no CLI command to inspect it quickly from the terminal.

## Validation
- `go test ./cmd/aegisctl`

Closes #49
