### PR TITLE
Add benchmark harness and CI workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,33 @@
+name: Benchmark
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install hey
+        run: go install github.com/rakyll/hey@latest
+
+      - name: Run benchmark
+        env:
+          BENCH_RESULTS_FILE: benchmark-results.txt
+        run: |
+          export PATH="$PATH:$(go env GOPATH)/bin"
+          bash scripts/benchmark.sh
+
+      - name: Upload benchmark artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: benchmark-results.txt

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run test lint fmt docker-build docker-up clean
+.PHONY: build run test lint fmt docker-build docker-up benchmark clean
 
 BINARY=aegisflow
 CONFIG=configs/aegisflow.yaml
@@ -24,6 +24,9 @@ docker-build:
 
 docker-up:
 	docker compose -f deployments/docker-compose.yaml up --build
+
+benchmark:
+	bash scripts/benchmark.sh
 
 clean:
 	rm -rf bin/

--- a/configs/benchmark.yaml
+++ b/configs/benchmark.yaml
@@ -1,0 +1,82 @@
+server:
+  host: "127.0.0.1"
+  port: 18081
+  admin_port: 18082
+  read_timeout: 30s
+  write_timeout: 120s
+  graceful_shutdown: 10s
+  max_body_size: 10485760
+
+gateway:
+  request_validation: true
+
+compression:
+  enabled: true
+  min_size_bytes: 512
+
+providers:
+  - name: "bench-openai"
+    type: "openai"
+    enabled: true
+    base_url: "http://127.0.0.1:18080/v1"
+    api_keys:
+      - key: "bench-key"
+        weight: 1
+    key_selection: "round-robin"
+    retry:
+      max_attempts: 2
+      initial_backoff: 100ms
+      max_backoff: 500ms
+      backoff_multiplier: 2.0
+      jitter: true
+      retryable_status_codes: [429, 500, 502, 503, 504]
+    models:
+      - "gpt-4o-mini"
+    timeout: 10s
+
+routes:
+  - match:
+      model: "*"
+    providers: ["bench-openai"]
+    strategy: "priority"
+
+tenants:
+  - id: "benchmark"
+    name: "Benchmark Tenant"
+    api_keys:
+      - key: "benchmark-key"
+        role: "admin"
+    rate_limit:
+      requests_per_minute: 10000
+      tokens_per_minute: 10000000
+    allowed_models:
+      - "*"
+
+rate_limit:
+  backend: "memory"
+
+policies:
+  input: []
+  output: []
+
+telemetry:
+  enabled: false
+
+logging:
+  level: "info"
+  format: "json"
+
+cache:
+  enabled: true
+  backend: "memory"
+  ttl: 2m
+  max_size: 1000
+
+webhook:
+  url: ""
+
+database:
+  enabled: false
+
+admin:
+  token: ""

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Benchmark AegisFlow against the local mock provider.
+# Usage:
+#   scripts/benchmark.sh
+# Optional env vars:
+#   BENCH_REQUESTS=300
+#   BENCH_CONCURRENCY=20
+#   BENCH_P99_THRESHOLD_MS=250
+#   BENCH_RESULTS_FILE=benchmark-results.txt
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REQUESTS="${BENCH_REQUESTS:-300}"
+CONCURRENCY="${BENCH_CONCURRENCY:-20}"
+P99_THRESHOLD_MS="${BENCH_P99_THRESHOLD_MS:-250}"
+RESULTS_FILE="${BENCH_RESULTS_FILE:-$ROOT_DIR/benchmark-results.txt}"
+TMP_DIR="$(mktemp -d)"
+MOCK_LOG="$TMP_DIR/mock-provider.log"
+GATEWAY_LOG="$TMP_DIR/aegisflow.log"
+PAYLOAD_FILE="$TMP_DIR/payload.json"
+CSV_FILE="$TMP_DIR/benchmark.csv"
+
+cleanup() {
+  if [[ -n "${GATEWAY_PID:-}" ]]; then
+    kill "${GATEWAY_PID}" >/dev/null 2>&1 || true
+    wait "${GATEWAY_PID}" 2>/dev/null || true
+  fi
+  if [[ -n "${MOCK_PID:-}" ]]; then
+    kill "${MOCK_PID}" >/dev/null 2>&1 || true
+    wait "${MOCK_PID}" 2>/dev/null || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+wait_for_http() {
+  local url="$1"
+  for _ in $(seq 1 60); do
+    if curl -fsS "$url" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.5
+  done
+  echo "timed out waiting for $url" >&2
+  exit 1
+}
+
+require_cmd curl
+require_cmd go
+
+if ! command -v hey >/dev/null 2>&1; then
+  export GOBIN="$TMP_DIR/bin"
+  mkdir -p "$GOBIN"
+  go install github.com/rakyll/hey@latest
+  export PATH="$GOBIN:$PATH"
+fi
+
+cat >"$PAYLOAD_FILE" <<'JSON'
+{
+  "model": "gpt-4o-mini",
+  "messages": [
+    {"role": "system", "content": "You are a concise assistant."},
+    {"role": "user", "content": "Summarize why gateway benchmarking matters for regressions and performance tracking."}
+  ],
+  "temperature": 0.2,
+  "max_tokens": 120
+}
+JSON
+
+(
+  cd "$ROOT_DIR"
+  go run ./scripts/mock_provider.go -listen 127.0.0.1:18080 -latency 25ms >"$MOCK_LOG" 2>&1
+) &
+MOCK_PID=$!
+
+(
+  cd "$ROOT_DIR"
+  go run ./cmd/aegisflow --config configs/benchmark.yaml >"$GATEWAY_LOG" 2>&1
+) &
+GATEWAY_PID=$!
+
+wait_for_http "http://127.0.0.1:18080/health"
+wait_for_http "http://127.0.0.1:18081/health"
+
+START_NS="$(date +%s%N)"
+hey -n "$REQUESTS" -c "$CONCURRENCY" \
+  -o csv \
+  -m POST \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: benchmark-key" \
+  -D "$PAYLOAD_FILE" \
+  http://127.0.0.1:18081/v1/chat/completions >"$CSV_FILE"
+END_NS="$(date +%s%N)"
+
+TOTAL_REQUESTS="$(tail -n +2 "$CSV_FILE" | wc -l | tr -d ' ')"
+ELAPSED_SECONDS="$(awk -v start="$START_NS" -v finish="$END_NS" 'BEGIN { printf "%.6f", (finish - start) / 1000000000 }')"
+RPS="$(awk -v total="$TOTAL_REQUESTS" -v elapsed="$ELAPSED_SECONDS" 'BEGIN { if (elapsed == 0) printf "0.0000"; else printf "%.4f", total / elapsed }')"
+NON_2XX="$(awk -F, 'NR > 1 && $7 !~ /^2/ {count++} END {print count + 0}' "$CSV_FILE")"
+ERROR_RATE="$(awk -v bad="$NON_2XX" -v total="$TOTAL_REQUESTS" 'BEGIN { if (total == 0) printf "0.00"; else printf "%.2f", (bad / total) * 100 }')"
+
+percentile_seconds() {
+  local percentile="$1"
+  local index
+  index="$(awk -v count="$TOTAL_REQUESTS" -v pct="$percentile" 'BEGIN { idx = int((pct / 100.0) * count + 0.999999); if (idx < 1) idx = 1; print idx }')"
+  tail -n +2 "$CSV_FILE" | cut -d, -f1 | sort -n | sed -n "${index}p"
+}
+
+P50_SECONDS="$(percentile_seconds 50)"
+P95_SECONDS="$(percentile_seconds 95)"
+P99_SECONDS="$(percentile_seconds 99)"
+P50_MS="$(awk -v secs="${P50_SECONDS:-0}" 'BEGIN { printf "%.2f", secs * 1000 }')"
+P95_MS="$(awk -v secs="${P95_SECONDS:-0}" 'BEGIN { printf "%.2f", secs * 1000 }')"
+P99_MS="$(awk -v secs="${P99_SECONDS:-0}" 'BEGIN { printf "%.2f", secs * 1000 }')"
+
+{
+  echo "Benchmark summary"
+  echo "Requests/sec: ${RPS:-0}"
+  echo "P50 latency (ms): $P50_MS"
+  echo "P95 latency (ms): $P95_MS"
+  echo "P99 latency (ms): $P99_MS"
+  echo "Error rate (%): $ERROR_RATE"
+  echo
+  echo "Raw CSV"
+  cat "$CSV_FILE"
+} >"$RESULTS_FILE"
+
+cat "$RESULTS_FILE"
+
+if awk -v p99="$P99_MS" -v threshold="$P99_THRESHOLD_MS" 'BEGIN { exit !(p99 > threshold) }'; then
+  echo "benchmark failed: p99 ${P99_MS}ms exceeded threshold ${P99_THRESHOLD_MS}ms" >&2
+  exit 1
+fi

--- a/scripts/mock_provider.go
+++ b/scripts/mock_provider.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/saivedant169/AegisFlow/pkg/types"
+)
+
+func main() {
+	listenAddr := flag.String("listen", ":18080", "listen address")
+	latency := flag.Duration("latency", 25*time.Millisecond, "response latency")
+	flag.Parse()
+
+	server := &http.Server{
+		Addr:    *listenAddr,
+		Handler: newMockProviderHandler(*latency),
+	}
+
+	log.Printf("mock provider listening on %s with latency %s", *listenAddr, *latency)
+	log.Fatal(server.ListenAndServe())
+}
+
+func newMockProviderHandler(latency time.Duration) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/chat/completions", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if latency > 0 {
+			time.Sleep(latency)
+		}
+
+		var req types.ChatCompletionRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, `{"error":"invalid json"}`, http.StatusBadRequest)
+			return
+		}
+
+		prompt := ""
+		for _, msg := range req.Messages {
+			if msg.Role == "user" {
+				prompt = msg.Content
+			}
+		}
+		reply := "Benchmark response for: " + prompt
+		resp := types.ChatCompletionResponse{
+			ID:      "bench-mock-1",
+			Object:  "chat.completion",
+			Created: time.Now().Unix(),
+			Model:   req.Model,
+			Choices: []types.Choice{{
+				Index:        0,
+				Message:      types.Message{Role: "assistant", Content: reply},
+				FinishReason: "stop",
+			}},
+			Usage: types.Usage{
+				PromptTokens:     estimateTokens(prompt),
+				CompletionTokens: estimateTokens(reply),
+				TotalTokens:      estimateTokens(prompt) + estimateTokens(reply),
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	mux.HandleFunc("/v1/models", func(w http.ResponseWriter, r *http.Request) {
+		models := types.ModelList{
+			Object: "list",
+			Data: []types.Model{
+				{ID: "gpt-4o-mini", Object: "model", Provider: "bench-openai"},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(models)
+	})
+
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"status":"ok"}`))
+	})
+
+	return mux
+}
+
+func estimateTokens(text string) int {
+	if text == "" {
+		return 0
+	}
+	return len(strings.Fields(text)) * 2
+}

--- a/scripts/mock_provider_test.go
+++ b/scripts/mock_provider_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/saivedant169/AegisFlow/pkg/types"
+)
+
+func TestMockProviderChatCompletion(t *testing.T) {
+	handler := newMockProviderHandler(0)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello benchmark"}]}`))
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp types.ChatCompletionResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Model != "gpt-4o-mini" {
+		t.Fatalf("expected model gpt-4o-mini, got %q", resp.Model)
+	}
+	if len(resp.Choices) != 1 || !strings.Contains(resp.Choices[0].Message.Content, "hello benchmark") {
+		t.Fatalf("unexpected response body: %+v", resp.Choices)
+	}
+}
+
+func TestMockProviderModels(t *testing.T) {
+	handler := newMockProviderHandler(0)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "gpt-4o-mini") {
+		t.Fatalf("expected benchmark model in response, got %s", w.Body.String())
+	}
+}
+
+func TestMockProviderLatency(t *testing.T) {
+	handler := newMockProviderHandler(20 * time.Millisecond)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-4o-mini","messages":[{"role":"user","content":"latency"}]}`))
+	w := httptest.NewRecorder()
+
+	start := time.Now()
+	handler.ServeHTTP(w, req)
+
+	if time.Since(start) < 20*time.Millisecond {
+		t.Fatalf("expected configured latency to be applied")
+	}
+}


### PR DESCRIPTION
## Summary
- add a local benchmark script that boots a mock OpenAI-compatible upstream and runs `hey` against AegisFlow
- add a benchmark-specific gateway config and a mock provider with tests
- add a GitHub Actions workflow that runs the benchmark and uploads the results artifact
- add `make benchmark` for local execution

## Why
The repository did not have any repeatable load-testing path or CI benchmark job to catch latency and throughput regressions.

## Validation
- `go test ./scripts`
- `BENCH_REQUESTS=50 BENCH_CONCURRENCY=10 BENCH_P99_THRESHOLD_MS=5000 bash scripts/benchmark.sh`

Closes #25
