### PR TITLE
Show cache TTL on the dashboard

### DIFF
--- a/internal/admin/dashboard.html
+++ b/internal/admin/dashboard.html
@@ -582,7 +582,7 @@
         Auto-refresh 3s
       </div>
     </div>
-    <div class="stat-grid" style="grid-template-columns: repeat(5, 1fr); margin-bottom: 20px;">
+    <div class="stat-grid" style="grid-template-columns: repeat(6, 1fr); margin-bottom: 20px;">
       <div class="stat-card">
         <div class="stat-glow green"></div>
         <div class="stat-label">Hits</div>
@@ -607,6 +607,11 @@
         <div class="stat-glow orange"></div>
         <div class="stat-label">Evictions</div>
         <div class="stat-value" id="cacheEvictions">0</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-glow cyan"></div>
+        <div class="stat-label">TTL</div>
+        <div class="stat-value" id="cacheTTL">--</div>
       </div>
     </div>
     <div class="chart-card" style="margin-bottom:24px;">
@@ -1323,6 +1328,7 @@ async function fetchCache() {
     document.getElementById('cacheHitRate').textContent = rate + '%';
     document.getElementById('cacheSize').textContent = (data.size || 0) + ' / ' + (data.max_size || 0);
     document.getElementById('cacheEvictions').textContent = formatNumber(data.evictions || 0);
+    document.getElementById('cacheTTL').textContent = data.ttl || '--';
 
     // Update chart
     const now = new Date().toLocaleTimeString();

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -8,16 +8,17 @@ import (
 	"sync"
 	"time"
 
-	"github.com/saivedant169/AegisFlow/pkg/types"
 	"github.com/redis/go-redis/v9"
+	"github.com/saivedant169/AegisFlow/pkg/types"
 )
 
 type CacheStats struct {
-	Hits      int64 `json:"hits"`
-	Misses    int64 `json:"misses"`
-	Size      int   `json:"size"`
-	MaxSize   int   `json:"max_size"`
-	Evictions int64 `json:"evictions"`
+	Hits      int64  `json:"hits"`
+	Misses    int64  `json:"misses"`
+	Size      int    `json:"size"`
+	MaxSize   int    `json:"max_size"`
+	Evictions int64  `json:"evictions"`
+	TTL       string `json:"ttl,omitempty"`
 }
 
 type Cache interface {
@@ -124,6 +125,7 @@ func (c *MemoryCache) Stats() CacheStats {
 		Size:      len(c.entries),
 		MaxSize:   c.maxSize,
 		Evictions: c.evictions,
+		TTL:       c.ttl.String(),
 	}
 }
 
@@ -181,5 +183,5 @@ func (c *RedisCache) Stats() CacheStats {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	size, _ := c.client.DBSize(ctx).Result()
-	return CacheStats{Size: int(size)}
+	return CacheStats{Size: int(size), TTL: c.ttl.String()}
 }

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/saivedant169/AegisFlow/pkg/types"
 	"github.com/alicebob/miniredis/v2"
+	"github.com/saivedant169/AegisFlow/pkg/types"
 )
 
 func TestBuildKey(t *testing.T) {
@@ -183,6 +183,9 @@ func TestStatsReturnsCorrectCounts(t *testing.T) {
 	}
 	if stats.Evictions < 1 {
 		t.Errorf("expected at least 1 eviction, got %d", stats.Evictions)
+	}
+	if stats.TTL != time.Minute.String() {
+		t.Errorf("expected ttl %q, got %q", time.Minute.String(), stats.TTL)
 	}
 }
 


### PR DESCRIPTION
## Summary
- include the configured TTL in cache stats returned by the cache backends
- display the TTL value on the cache dashboard page alongside the existing cache metrics
- add cache stats coverage for the TTL field

## Why
The cache page exposed size and hit/miss data but did not show the configured retention window, which made the cache behavior harder to interpret.

## Validation
- `go test ./internal/cache ./internal/admin`

Closes #33
