### PR TITLE
Add a persistent dashboard theme toggle

### DIFF
--- a/internal/admin/dashboard.html
+++ b/internal/admin/dashboard.html
@@ -8,6 +8,16 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
+<script>
+  (function() {
+    try {
+      var theme = localStorage.getItem('aegisflow-theme');
+      if (theme === 'light' || theme === 'dark') {
+        document.documentElement.setAttribute('data-theme', theme);
+      }
+    } catch (e) {}
+  })();
+</script>
 <style>
   :root {
     --bg-primary: #030712;
@@ -31,6 +41,28 @@
     --gradient-purple: linear-gradient(135deg, #bc8cff 0%, #8957e5 100%);
     --gradient-orange: linear-gradient(135deg, #d29922 0%, #bb8009 100%);
   }
+  :root[data-theme="light"] {
+    --bg-primary: #f3efe6;
+    --bg-card: rgba(255, 252, 246, 0.92);
+    --bg-card-hover: #f6efe1;
+    --bg-elevated: #ece3d3;
+    --border: #d7ccb8;
+    --border-light: #c5b79f;
+    --text-primary: #1f1d1a;
+    --text-secondary: #5d5243;
+    --text-muted: #8f7f6a;
+    --accent-blue: #0f5cc0;
+    --accent-green: #237a4b;
+    --accent-purple: #7a4cc7;
+    --accent-orange: #b26c00;
+    --accent-red: #b42318;
+    --accent-cyan: #0d8093;
+    --accent-pink: #bf4f7b;
+    --gradient-blue: linear-gradient(135deg, #2563eb 0%, #0f5cc0 100%);
+    --gradient-green: linear-gradient(135deg, #2f9e62 0%, #237a4b 100%);
+    --gradient-purple: linear-gradient(135deg, #8b5cf6 0%, #7a4cc7 100%);
+    --gradient-orange: linear-gradient(135deg, #d97706 0%, #b26c00 100%);
+  }
   * { margin: 0; padding: 0; box-sizing: border-box; }
   body {
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
@@ -43,6 +75,12 @@
       radial-gradient(ellipse 600px 400px at 20% 10%, rgba(88, 166, 255, 0.12), transparent 70%),
       radial-gradient(ellipse 500px 350px at 75% 20%, rgba(188, 140, 255, 0.08), transparent 70%),
       radial-gradient(ellipse 400px 300px at 50% 80%, rgba(63, 185, 80, 0.05), transparent 70%);
+  }
+  :root[data-theme="light"] body::before {
+    background:
+      radial-gradient(ellipse 700px 480px at 15% 10%, rgba(37, 99, 235, 0.10), transparent 70%),
+      radial-gradient(ellipse 640px 420px at 80% 15%, rgba(217, 119, 6, 0.10), transparent 70%),
+      radial-gradient(ellipse 520px 380px at 55% 78%, rgba(47, 158, 98, 0.08), transparent 70%);
   }
 
   @media (prefers-reduced-motion: reduce) {
@@ -109,6 +147,12 @@
 
   .sidebar-footer { padding: 16px 20px; border-top: 1px solid var(--border); }
   .sidebar-footer .status-row { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--text-secondary); }
+  .sidebar-footer .theme-toggle {
+    margin-top: 10px; width: 100%; border: 1px solid var(--border); border-radius: 10px;
+    background: var(--bg-card); color: var(--text-primary); padding: 9px 12px; font-size: 12px;
+    font-weight: 600; cursor: pointer; transition: all 0.15s ease;
+  }
+  .sidebar-footer .theme-toggle:hover { background: var(--bg-card-hover); border-color: var(--border-light); }
   .status-dot {
     width: 8px; height: 8px; border-radius: 50%; background: var(--accent-green); flex-shrink: 0;
     animation: pulse 2s ease-in-out infinite;
@@ -328,6 +372,7 @@
     <div class="status-row" style="margin-top:6px;">
       <span id="lastUpdate" style="font-size:11px;">--</span>
     </div>
+    <button class="theme-toggle" id="themeToggle" onclick="toggleTheme()">Switch To Light Theme</button>
   </div>
 </div>
 
@@ -979,6 +1024,23 @@ function formatNumber(n) {
   if (n >= 1000000) return (n / 1000000).toFixed(1) + 'M';
   if (n >= 1000) return (n / 1000).toFixed(1) + 'K';
   return n.toLocaleString();
+}
+
+function applyTheme(theme) {
+  const nextTheme = theme === 'light' ? 'light' : 'dark';
+  document.documentElement.setAttribute('data-theme', nextTheme);
+  try {
+    localStorage.setItem('aegisflow-theme', nextTheme);
+  } catch (e) {}
+  const button = document.getElementById('themeToggle');
+  if (button) {
+    button.textContent = nextTheme === 'light' ? 'Switch To Dark Theme' : 'Switch To Light Theme';
+  }
+}
+
+function toggleTheme() {
+  const current = document.documentElement.getAttribute('data-theme') === 'light' ? 'light' : 'dark';
+  applyTheme(current === 'light' ? 'dark' : 'light');
 }
 
 async function fetchUsage() {
@@ -1963,6 +2025,7 @@ async function fetchWhoami() {
 }
 
 initCharts();
+applyTheme(document.documentElement.getAttribute('data-theme'));
 fetchWhoami();
 fetchUsage();
 fetchOverviewStatus();


### PR DESCRIPTION
## Summary
- add a theme toggle button to the dashboard sidebar footer
- define a light-theme variable set that reuses the existing component structure
- persist the selected theme in `localStorage` and restore it on page load

## Why
The dashboard was dark-only. This adds a lightweight, persistent light mode without changing the page structure or data flow.

## Validation
- verified the toggle wiring and persistence logic in `internal/admin/dashboard.html`

Closes #32
