### PR TITLE
Add actor_role filtering to the audit API

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -40,7 +40,7 @@ type BudgetProvider interface {
 // cycle with the audit package. Use audit.NewAdminAdapter to wrap a
 // *audit.Logger so it satisfies this interface.
 type AuditProvider interface {
-	Query(actor, action, tenantID string, limit int) (interface{}, error)
+	Query(actor, actorRole, action, tenantID string, limit int) (interface{}, error)
 	Verify() (interface{}, error)
 }
 
@@ -495,10 +495,11 @@ func (s *Server) auditHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	actor := r.URL.Query().Get("actor")
+	actorRole := r.URL.Query().Get("actor_role")
 	action := r.URL.Query().Get("action")
 	tenantID := r.URL.Query().Get("tenant_id")
 	limit := 100 // default
-	result, err := s.auditProvider.Query(actor, action, tenantID, limit)
+	result, err := s.auditProvider.Query(actor, actorRole, action, tenantID, limit)
 	if err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)

--- a/internal/audit/adminadapter.go
+++ b/internal/audit/adminadapter.go
@@ -9,9 +9,9 @@ func NewAdminAdapter(l *Logger) *AdminAdapter {
 	return &AdminAdapter{logger: l}
 }
 
-func (a *AdminAdapter) Query(actor, action, tenantID string, limit int) (interface{}, error) {
+func (a *AdminAdapter) Query(actor, actorRole, action, tenantID string, limit int) (interface{}, error) {
 	return a.logger.Query(QueryFilters{
-		Actor: actor, Action: action, TenantID: tenantID, Limit: limit,
+		Actor: actor, ActorRole: actorRole, Action: action, TenantID: tenantID, Limit: limit,
 	})
 }
 

--- a/internal/audit/adminadapter_test.go
+++ b/internal/audit/adminadapter_test.go
@@ -17,7 +17,7 @@ func TestAdminAdapterQuery(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	adapter := NewAdminAdapter(logger)
-	result, err := adapter.Query("", "", "", 0)
+	result, err := adapter.Query("", "", "", "", 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -38,12 +38,13 @@ type Store interface {
 }
 
 type QueryFilters struct {
-	Actor    string
-	Action   string
-	TenantID string
-	From     time.Time
-	To       time.Time
-	Limit    int
+	Actor     string
+	ActorRole string
+	Action    string
+	TenantID  string
+	From      time.Time
+	To        time.Time
+	Limit     int
 }
 
 func NewLogger(store Store) (*Logger, error) {

--- a/internal/audit/logger_test.go
+++ b/internal/audit/logger_test.go
@@ -241,6 +241,23 @@ func TestMemoryStoreQueryReturnsAllInOrder(t *testing.T) {
 	}
 }
 
+func TestMemoryStoreQueryFiltersActorRole(t *testing.T) {
+	store := NewMemoryStore()
+	_ = store.Insert(Entry{Actor: "alice", ActorRole: "admin", Action: "a1", Detail: "{}"})
+	_ = store.Insert(Entry{Actor: "bob", ActorRole: "viewer", Action: "a2", Detail: "{}"})
+
+	entries, err := store.Query(QueryFilters{ActorRole: "admin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Actor != "alice" {
+		t.Fatalf("expected alice, got %s", entries[0].Actor)
+	}
+}
+
 func TestComputeHashDeterministic(t *testing.T) {
 	e := Entry{
 		Timestamp: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),

--- a/internal/audit/memory_store.go
+++ b/internal/audit/memory_store.go
@@ -37,7 +37,30 @@ func (s *MemoryStore) LastHash() (string, error) {
 func (s *MemoryStore) Query(filters QueryFilters) ([]Entry, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	result := make([]Entry, len(s.entries))
-	copy(result, s.entries)
+	result := make([]Entry, 0, len(s.entries))
+	for _, entry := range s.entries {
+		if filters.Actor != "" && entry.Actor != filters.Actor {
+			continue
+		}
+		if filters.ActorRole != "" && entry.ActorRole != filters.ActorRole {
+			continue
+		}
+		if filters.Action != "" && entry.Action != filters.Action {
+			continue
+		}
+		if filters.TenantID != "" && entry.TenantID != filters.TenantID {
+			continue
+		}
+		if !filters.From.IsZero() && entry.Timestamp.Before(filters.From) {
+			continue
+		}
+		if !filters.To.IsZero() && entry.Timestamp.After(filters.To) {
+			continue
+		}
+		result = append(result, entry)
+	}
+	if filters.Limit > 0 && len(result) > filters.Limit {
+		result = result[:filters.Limit]
+	}
 	return result, nil
 }

--- a/internal/audit/pgstore/store.go
+++ b/internal/audit/pgstore/store.go
@@ -70,6 +70,11 @@ func (s *PostgresStore) Query(filters audit.QueryFilters) ([]audit.Entry, error)
 		args = append(args, filters.Actor)
 		argIdx++
 	}
+	if filters.ActorRole != "" {
+		query += fmt.Sprintf(" AND actor_role = $%d", argIdx)
+		args = append(args, filters.ActorRole)
+		argIdx++
+	}
 	if filters.Action != "" {
 		query += fmt.Sprintf(" AND action = $%d", argIdx)
 		args = append(args, filters.Action)


### PR DESCRIPTION
Summary
- accept an `actor_role` query parameter on `/admin/v1/audit`
- propagate the filter through the admin adapter and audit stores
- add coverage for the new filter in the in-memory store tests

Why
- operators need to narrow audit investigations by role without client-side filtering

Validation
- `go test ./internal/audit`
- `go test ./internal/admin`

Closes #46