### PR TITLE
Add provider-aware usage breakdowns

### DIFF
--- a/internal/admin/dashboard.html
+++ b/internal/admin/dashboard.html
@@ -462,6 +462,7 @@
         <tr>
           <th>Tenant</th>
           <th>Model</th>
+          <th>Provider</th>
           <th>Requests</th>
           <th>Token Split</th>
           <th>Total Tokens</th>
@@ -469,7 +470,7 @@
         </tr>
       </thead>
       <tbody id="usageTable">
-        <tr><td colspan="6" class="empty-state"><p>No usage data yet</p><div class="hint">Send a request: curl -X POST http://localhost:8080/v1/chat/completions ...</div></td></tr>
+        <tr><td colspan="7" class="empty-state"><p>No usage data yet</p><div class="hint">Send a request: curl -X POST http://localhost:8080/v1/chat/completions ...</div></td></tr>
       </tbody>
     </table>
   </div>
@@ -975,6 +976,13 @@ function getModelBadgeClass(model) {
   return 'badge-model';
 }
 
+function getProviderBadgeClass(provider) {
+  if (provider === 'openai') return 'badge-openai';
+  if (provider === 'ollama') return 'badge-ollama';
+  if (provider === 'mock') return 'badge-mock';
+  return 'badge-model';
+}
+
 function formatNumber(n) {
   if (n >= 1000000) return (n / 1000000).toFixed(1) + 'M';
   if (n >= 1000) return (n / 1000).toFixed(1) + 'K';
@@ -999,20 +1007,27 @@ async function fetchUsage() {
 
       tenantData[tenantId] = { prompt: 0, completion: 0 };
 
-      for (const [model, m] of Object.entries(tenant.by_model || {})) {
+      const providerModelEntries = Object.values(tenant.by_provider_model || {});
+      const usageEntries = providerModelEntries.length > 0 ? providerModelEntries : Object.values(tenant.by_model || {});
+
+      for (const m of usageEntries) {
+        const model = m.model;
         modelMap[model] = (modelMap[model] || 0) + m.requests;
         totalPrompt += m.prompt_tokens;
         totalCompletion += m.completion_tokens;
         tenantData[tenantId].prompt += m.prompt_tokens;
         tenantData[tenantId].completion += m.completion_tokens;
 
-        let provider = 'mock';
-        if (model.startsWith('gpt')) provider = 'openai';
-        else if (model.startsWith('qwen') || model.startsWith('llama')) provider = 'ollama';
-        else if (model.startsWith('claude')) provider = 'anthropic';
+        let provider = m.provider || 'unknown';
+        if (!m.provider) {
+          if (model.startsWith('gpt')) provider = 'openai';
+          else if (model.startsWith('qwen') || model.startsWith('llama')) provider = 'ollama';
+          else if (model.startsWith('claude')) provider = 'anthropic';
+          else provider = 'mock';
+        }
         providerRequests[provider] = (providerRequests[provider] || 0) + m.requests;
 
-        rows.push({ tenant: tenantId, model, requests: m.requests, promptTokens: m.prompt_tokens, completionTokens: m.completion_tokens, totalTokens: m.total_tokens, cost: m.estimated_cost_usd });
+        rows.push({ tenant: tenantId, model, provider, requests: m.requests, promptTokens: m.prompt_tokens, completionTokens: m.completion_tokens, totalTokens: m.total_tokens, cost: m.estimated_cost_usd });
       }
     }
 
@@ -1079,7 +1094,7 @@ async function fetchUsage() {
     const tbody = document.getElementById('usageTable');
     document.getElementById('rowCount').textContent = rows.length + ' entries';
     if (rows.length === 0) {
-      tbody.innerHTML = '<tr><td colspan="6" class="empty-state"><p>No usage data yet</p></td></tr>';
+      tbody.innerHTML = '<tr><td colspan="7" class="empty-state"><p>No usage data yet</p></td></tr>';
     } else {
       rows.sort((a, b) => b.totalTokens - a.totalTokens);
       tbody.innerHTML = rows.map(r => {
@@ -1089,6 +1104,7 @@ async function fetchUsage() {
         return `<tr>
           <td><span class="badge badge-tenant">${r.tenant}</span></td>
           <td><span class="badge ${getModelBadgeClass(r.model)}">${r.model}</span></td>
+          <td><span class="badge ${getProviderBadgeClass(r.provider)}">${r.provider}</span></td>
           <td>${r.requests.toLocaleString()}</td>
           <td>
             <div style="display:flex;align-items:center;gap:8px;">

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -197,7 +197,7 @@ func (h *Handler) ChatCompletion(w http.ResponseWriter, r *http.Request) {
 
 	// Track usage
 	if h.usage != nil {
-		h.usage.Record(tenantID, req.Model, resp.Usage)
+		h.usage.Record(tenantID, providerName, req.Model, resp.Usage)
 	}
 
 	// Persist to database via buffered worker queue (non-blocking)

--- a/internal/usage/store.go
+++ b/internal/usage/store.go
@@ -15,12 +15,23 @@ type ModelUsage struct {
 	EstimatedCostUSD float64 `json:"estimated_cost_usd"`
 }
 
+type ProviderModelUsage struct {
+	Provider         string  `json:"provider"`
+	Model            string  `json:"model"`
+	Requests         int64   `json:"requests"`
+	PromptTokens     int64   `json:"prompt_tokens"`
+	CompletionTokens int64   `json:"completion_tokens"`
+	TotalTokens      int64   `json:"total_tokens"`
+	EstimatedCostUSD float64 `json:"estimated_cost_usd"`
+}
+
 type TenantUsage struct {
-	TenantID         string                `json:"tenant_id"`
-	TotalRequests    int64                 `json:"total_requests"`
-	TotalTokens      int64                 `json:"total_tokens"`
-	EstimatedCostUSD float64               `json:"estimated_cost_usd"`
-	ByModel          map[string]*ModelUsage `json:"by_model"`
+	TenantID         string                         `json:"tenant_id"`
+	TotalRequests    int64                          `json:"total_requests"`
+	TotalTokens      int64                          `json:"total_tokens"`
+	EstimatedCostUSD float64                        `json:"estimated_cost_usd"`
+	ByModel          map[string]*ModelUsage         `json:"by_model"`
+	ByProviderModel  map[string]*ProviderModelUsage `json:"by_provider_model,omitempty"`
 }
 
 type Store struct {
@@ -34,15 +45,16 @@ func NewStore() *Store {
 	}
 }
 
-func (s *Store) Add(tenantID, model string, u types.Usage, cost float64) {
+func (s *Store) Add(tenantID, providerName, model string, u types.Usage, cost float64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	t, ok := s.tenants[tenantID]
 	if !ok {
 		t = &TenantUsage{
-			TenantID: tenantID,
-			ByModel:  make(map[string]*ModelUsage),
+			TenantID:        tenantID,
+			ByModel:         make(map[string]*ModelUsage),
+			ByProviderModel: make(map[string]*ProviderModelUsage),
 		}
 		s.tenants[tenantID] = t
 	}
@@ -62,6 +74,19 @@ func (s *Store) Add(tenantID, model string, u types.Usage, cost float64) {
 	m.CompletionTokens += int64(u.CompletionTokens)
 	m.TotalTokens += int64(u.TotalTokens)
 	m.EstimatedCostUSD += cost
+
+	providerKey := providerName + "\x00" + model
+	pm, ok := t.ByProviderModel[providerKey]
+	if !ok {
+		pm = &ProviderModelUsage{Provider: providerName, Model: model}
+		t.ByProviderModel[providerKey] = pm
+	}
+
+	pm.Requests++
+	pm.PromptTokens += int64(u.PromptTokens)
+	pm.CompletionTokens += int64(u.CompletionTokens)
+	pm.TotalTokens += int64(u.TotalTokens)
+	pm.EstimatedCostUSD += cost
 }
 
 func (s *Store) Get(tenantID string) *TenantUsage {

--- a/internal/usage/store_test.go
+++ b/internal/usage/store_test.go
@@ -1,0 +1,38 @@
+package usage
+
+import (
+	"testing"
+
+	"github.com/saivedant169/AegisFlow/pkg/types"
+)
+
+func TestStoreAddsProviderBreakdown(t *testing.T) {
+	store := NewStore()
+	u := types.Usage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15}
+
+	store.Add("tenant-1", "openai", "gpt-4o", u, 1.25)
+	store.Add("tenant-1", "openai", "gpt-4o", u, 1.25)
+	store.Add("tenant-1", "anthropic", "gpt-4o", u, 0.75)
+
+	got := store.Get("tenant-1")
+	if got == nil {
+		t.Fatal("expected tenant usage")
+	}
+	if got.TotalRequests != 3 {
+		t.Fatalf("expected 3 total requests, got %d", got.TotalRequests)
+	}
+	if got.ByModel["gpt-4o"].Requests != 3 {
+		t.Fatalf("expected aggregated model requests to be 3, got %d", got.ByModel["gpt-4o"].Requests)
+	}
+	if len(got.ByProviderModel) != 2 {
+		t.Fatalf("expected 2 provider/model entries, got %d", len(got.ByProviderModel))
+	}
+	openAI := got.ByProviderModel["openai\x00gpt-4o"]
+	if openAI == nil || openAI.Requests != 2 {
+		t.Fatalf("expected openai entry to have 2 requests, got %+v", openAI)
+	}
+	anthropic := got.ByProviderModel["anthropic\x00gpt-4o"]
+	if anthropic == nil || anthropic.Requests != 1 {
+		t.Fatalf("expected anthropic entry to have 1 request, got %+v", anthropic)
+	}
+}

--- a/internal/usage/tracker.go
+++ b/internal/usage/tracker.go
@@ -21,9 +21,9 @@ func NewTracker(store *Store) *Tracker {
 	return &Tracker{store: store}
 }
 
-func (t *Tracker) Record(tenantID, model string, usage types.Usage) {
+func (t *Tracker) Record(tenantID, providerName, model string, usage types.Usage) {
 	cost := estimateCost(model, usage.TotalTokens)
-	t.store.Add(tenantID, model, usage, cost)
+	t.store.Add(tenantID, providerName, model, usage, cost)
 }
 
 func (t *Tracker) GetUsage(tenantID string) *TenantUsage {


### PR DESCRIPTION
Summary
- persist provider and model aggregates in the usage store
- record provider names from the gateway when usage is tracked
- show a dedicated Provider column in the dashboard usage table

Why
- the current usage API only aggregates by model, which makes provider-level usage impossible to review accurately

Validation
- `go test ./internal/usage`
- `go test ./internal/gateway`
- `go test ./internal/admin`

Closes #28