### PR TITLE
Add provider-specific model cost configuration

### DIFF
--- a/cmd/aegisflow/main.go
+++ b/cmd/aegisflow/main.go
@@ -89,7 +89,7 @@ func main() {
 	rt := router.NewRouter(cfg.Routes, registry)
 	pe := initPolicyEngine(cfg)
 	usageStore := usage.NewStore()
-	ut := usage.NewTracker(usageStore)
+	ut := usage.NewTrackerWithProviders(usageStore, cfg.Providers)
 
 	// Response cache
 	var responseCache cache.Cache

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -169,18 +169,25 @@ type CORSConfig struct {
 }
 
 type ProviderConfig struct {
-	Name       string            `yaml:"name"`
-	Type       string            `yaml:"type"`
-	Enabled    bool              `yaml:"enabled"`
-	Default    bool              `yaml:"default"`
-	BaseURL    string            `yaml:"base_url"`
-	APIKeyEnv  string            `yaml:"api_key_env"`
-	Models     []string          `yaml:"models"`
-	Timeout    time.Duration     `yaml:"timeout"`
-	MaxRetries int               `yaml:"max_retries"`
-	APIVersion string            `yaml:"api_version"`
-	Config     map[string]string `yaml:"config"`
-	Region     string            `yaml:"region"`
+	Name        string               `yaml:"name"`
+	Type        string               `yaml:"type"`
+	Enabled     bool                 `yaml:"enabled"`
+	Default     bool                 `yaml:"default"`
+	BaseURL     string               `yaml:"base_url"`
+	APIKeyEnv   string               `yaml:"api_key_env"`
+	Models      []string             `yaml:"models"`
+	Timeout     time.Duration        `yaml:"timeout"`
+	MaxRetries  int                  `yaml:"max_retries"`
+	APIVersion  string               `yaml:"api_version"`
+	Config      map[string]string    `yaml:"config"`
+	Region      string               `yaml:"region"`
+	ModelCosts  map[string]ModelCost `yaml:"model_costs"`
+	DefaultCost ModelCost            `yaml:"default_cost"`
+}
+
+type ModelCost struct {
+	InputPer1M  float64 `yaml:"input_per_1m"`
+	OutputPer1M float64 `yaml:"output_per_1m"`
 }
 
 type RegionConfig struct {
@@ -313,6 +320,9 @@ func Load(path string) (*Config, error) {
 	}
 
 	setDefaults(cfg)
+	if err := validateConfig(cfg); err != nil {
+		return nil, err
+	}
 	return cfg, nil
 }
 
@@ -443,4 +453,18 @@ func (c *Config) FindTenantByAPIKey(apiKey string) *TenantMatch {
 		}
 	}
 	return match
+}
+
+func validateConfig(cfg *Config) error {
+	for _, provider := range cfg.Providers {
+		for model, cost := range provider.ModelCosts {
+			if cost.InputPer1M < 0 || cost.OutputPer1M < 0 {
+				return fmt.Errorf("provider %q model_costs[%q] cannot be negative", provider.Name, model)
+			}
+		}
+		if provider.DefaultCost.InputPer1M < 0 || provider.DefaultCost.OutputPer1M < 0 {
+			return fmt.Errorf("provider %q default_cost cannot be negative", provider.Name)
+		}
+	}
+	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -910,3 +910,69 @@ federation:
 		t.Errorf("expected sync interval 1m, got %v", cfg.Federation.ControlPlane.SyncInterval)
 	}
 }
+
+func TestProviderModelCostsParsing(t *testing.T) {
+	yamlData := `
+providers:
+  - name: "openai"
+    type: "openai"
+    enabled: true
+    model_costs:
+      gpt-4o:
+        input_per_1m: 2.5
+        output_per_1m: 10.0
+    default_cost:
+      input_per_1m: 1.0
+      output_per_1m: 2.0
+`
+	f, err := os.CreateTemp("", "aegisflow-model-costs-*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.WriteString(yamlData); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	cfg, err := Load(f.Name())
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+	if len(cfg.Providers) != 1 {
+		t.Fatalf("expected 1 provider, got %d", len(cfg.Providers))
+	}
+	cost := cfg.Providers[0].ModelCosts["gpt-4o"]
+	if cost.InputPer1M != 2.5 || cost.OutputPer1M != 10.0 {
+		t.Fatalf("unexpected model cost: %+v", cost)
+	}
+	if cfg.Providers[0].DefaultCost.InputPer1M != 1.0 || cfg.Providers[0].DefaultCost.OutputPer1M != 2.0 {
+		t.Fatalf("unexpected default cost: %+v", cfg.Providers[0].DefaultCost)
+	}
+}
+
+func TestProviderModelCostsRejectNegativeValues(t *testing.T) {
+	yamlData := `
+providers:
+  - name: "openai"
+    type: "openai"
+    enabled: true
+    model_costs:
+      gpt-4o:
+        input_per_1m: -2.5
+        output_per_1m: 10.0
+`
+	f, err := os.CreateTemp("", "aegisflow-model-costs-negative-*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.WriteString(yamlData); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	if _, err := Load(f.Name()); err == nil {
+		t.Fatal("expected negative model cost to be rejected")
+	}
+}

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -197,7 +197,7 @@ func (h *Handler) ChatCompletion(w http.ResponseWriter, r *http.Request) {
 
 	// Track usage
 	if h.usage != nil {
-		h.usage.Record(tenantID, req.Model, resp.Usage)
+		h.usage.Record(tenantID, providerName, req.Model, resp.Usage)
 	}
 
 	// Persist to database via buffered worker queue (non-blocking)

--- a/internal/usage/tracker.go
+++ b/internal/usage/tracker.go
@@ -1,28 +1,38 @@
 package usage
 
 import (
+	"github.com/saivedant169/AegisFlow/internal/config"
 	"github.com/saivedant169/AegisFlow/pkg/types"
 )
 
-var costPerMillionTokens = map[string]float64{
-	"gpt-4o":                    5.0,
-	"gpt-4o-mini":               0.15,
-	"claude-sonnet-4-20250514":  3.0,
-	"llama3":                    0.0,
-	"mock":                      0.0,
-	"mock-fast":                 0.0,
+var legacyCostPerMillionTokens = map[string]float64{
+	"gpt-4o":                   5.0,
+	"gpt-4o-mini":              0.15,
+	"claude-sonnet-4-20250514": 3.0,
+	"llama3":                   0.0,
+	"mock":                     0.0,
+	"mock-fast":                0.0,
 }
 
 type Tracker struct {
-	store *Store
+	store          *Store
+	providerConfig map[string]config.ProviderConfig
 }
 
 func NewTracker(store *Store) *Tracker {
 	return &Tracker{store: store}
 }
 
-func (t *Tracker) Record(tenantID, model string, usage types.Usage) {
-	cost := estimateCost(model, usage.TotalTokens)
+func NewTrackerWithProviders(store *Store, providers []config.ProviderConfig) *Tracker {
+	providerConfig := make(map[string]config.ProviderConfig, len(providers))
+	for _, provider := range providers {
+		providerConfig[provider.Name] = provider
+	}
+	return &Tracker{store: store, providerConfig: providerConfig}
+}
+
+func (t *Tracker) Record(tenantID, providerName, model string, usage types.Usage) {
+	cost := t.estimateCost(providerName, model, usage)
 	t.store.Add(tenantID, model, usage, cost)
 }
 
@@ -34,12 +44,21 @@ func (t *Tracker) GetAllUsage() map[string]*TenantUsage {
 	return t.store.GetAll()
 }
 
-func estimateCost(model string, tokens int) float64 {
-	rate, ok := costPerMillionTokens[model]
+func (t *Tracker) estimateCost(providerName, model string, usage types.Usage) float64 {
+	if provider, ok := t.providerConfig[providerName]; ok {
+		if cost, ok := provider.ModelCosts[model]; ok {
+			return (float64(usage.PromptTokens)*cost.InputPer1M + float64(usage.CompletionTokens)*cost.OutputPer1M) / 1_000_000.0
+		}
+		if provider.DefaultCost.InputPer1M > 0 || provider.DefaultCost.OutputPer1M > 0 {
+			return (float64(usage.PromptTokens)*provider.DefaultCost.InputPer1M + float64(usage.CompletionTokens)*provider.DefaultCost.OutputPer1M) / 1_000_000.0
+		}
+	}
+
+	rate, ok := legacyCostPerMillionTokens[model]
 	if !ok {
 		rate = 1.0
 	}
-	return float64(tokens) / 1_000_000.0 * rate
+	return float64(usage.TotalTokens) / 1_000_000.0 * rate
 }
 
 func EstimateTokens(text string) int {

--- a/internal/usage/tracker_test.go
+++ b/internal/usage/tracker_test.go
@@ -1,0 +1,65 @@
+package usage
+
+import (
+	"testing"
+
+	"github.com/saivedant169/AegisFlow/internal/config"
+	"github.com/saivedant169/AegisFlow/pkg/types"
+)
+
+func TestTrackerUsesProviderModelCosts(t *testing.T) {
+	tracker := NewTrackerWithProviders(NewStore(), []config.ProviderConfig{
+		{
+			Name: "openai",
+			ModelCosts: map[string]config.ModelCost{
+				"gpt-4o": {InputPer1M: 2.5, OutputPer1M: 10},
+			},
+		},
+	})
+
+	tracker.Record("tenant-1", "openai", "gpt-4o", types.Usage{
+		PromptTokens: 1000, CompletionTokens: 2000, TotalTokens: 3000,
+	})
+
+	got := tracker.GetUsage("tenant-1")
+	cost := got.ByModel["gpt-4o"].EstimatedCostUSD
+	want := (1000*2.5 + 2000*10.0) / 1_000_000.0
+	if cost != want {
+		t.Fatalf("expected cost %f, got %f", want, cost)
+	}
+}
+
+func TestTrackerUsesProviderDefaultCostFallback(t *testing.T) {
+	tracker := NewTrackerWithProviders(NewStore(), []config.ProviderConfig{
+		{
+			Name:        "openai",
+			DefaultCost: config.ModelCost{InputPer1M: 1.5, OutputPer1M: 3.5},
+		},
+	})
+
+	tracker.Record("tenant-1", "openai", "unknown-model", types.Usage{
+		PromptTokens: 1000, CompletionTokens: 2000, TotalTokens: 3000,
+	})
+
+	got := tracker.GetUsage("tenant-1")
+	cost := got.ByModel["unknown-model"].EstimatedCostUSD
+	want := (1000*1.5 + 2000*3.5) / 1_000_000.0
+	if cost != want {
+		t.Fatalf("expected cost %f, got %f", want, cost)
+	}
+}
+
+func TestTrackerLegacyFallbackPreserved(t *testing.T) {
+	tracker := NewTracker(NewStore())
+
+	tracker.Record("tenant-1", "openai", "gpt-4o", types.Usage{
+		PromptTokens: 10, CompletionTokens: 15, TotalTokens: 25,
+	})
+
+	got := tracker.GetUsage("tenant-1")
+	cost := got.ByModel["gpt-4o"].EstimatedCostUSD
+	want := 25 * 5.0 / 1_000_000.0
+	if cost != want {
+		t.Fatalf("expected cost %f, got %f", want, cost)
+	}
+}


### PR DESCRIPTION
Summary
- add `model_costs` and `default_cost` support to provider config
- validate cost values during config load
- use provider-specific pricing when estimating usage cost at runtime

Why
- a single global model price is not accurate once the same model name is served through multiple providers

Validation
- `go test ./internal/config`
- `go test ./internal/usage`
- `go test ./internal/gateway`
- `go test ./cmd/aegisflow`

Closes #17