### PR TITLE
Add provider API key rotation support

### DIFF
--- a/cmd/aegisflow/main.go
+++ b/cmd/aegisflow/main.go
@@ -412,7 +412,9 @@ func initProviders(cfg *config.Config, registry *provider.Registry) {
 			registry.Register(provider.NewMockProvider(pc.Name, latency))
 			log.Printf("registered provider: %s (type: mock, latency: %s)", pc.Name, latency)
 		case "openai":
-			registry.Register(provider.NewOpenAIProvider(pc.Name, pc.BaseURL, pc.APIKeyEnv, pc.Models, pc.Timeout, pc.MaxRetries))
+			p := provider.NewOpenAIProvider(pc.Name, pc.BaseURL, pc.APIKeyEnv, pc.Models, pc.Timeout, pc.MaxRetries)
+			p.ConfigureKeys(pc.APIKeys, pc.KeySelection, pc.KeyCooldown)
+			registry.Register(p)
 			log.Printf("registered provider: %s (type: openai, base_url: %s)", pc.Name, pc.BaseURL)
 		case "anthropic":
 			registry.Register(provider.NewAnthropicProvider(pc.Name, pc.BaseURL, pc.APIKeyEnv, pc.Models, pc.Timeout))
@@ -424,16 +426,24 @@ func initProviders(cfg *config.Config, registry *provider.Registry) {
 			registry.Register(provider.NewGeminiProvider(pc.Name, pc.APIKeyEnv, pc.Models, pc.Timeout))
 			log.Printf("registered provider: %s (type: gemini)", pc.Name)
 		case "azure_openai":
-			registry.Register(provider.NewAzureOpenAIProvider(pc.Name, pc.BaseURL, pc.APIKeyEnv, pc.APIVersion, pc.Models, pc.Timeout))
+			p := provider.NewAzureOpenAIProvider(pc.Name, pc.BaseURL, pc.APIKeyEnv, pc.APIVersion, pc.Models, pc.Timeout)
+			p.ConfigureKeys(pc.APIKeys, pc.KeySelection, pc.KeyCooldown)
+			registry.Register(p)
 			log.Printf("registered provider: %s (type: azure_openai, endpoint: %s)", pc.Name, pc.BaseURL)
 		case "groq":
-			registry.Register(provider.NewGroqProvider(pc.Name, pc.APIKeyEnv, pc.Models, pc.Timeout))
+			p := provider.NewGroqProvider(pc.Name, pc.APIKeyEnv, pc.Models, pc.Timeout)
+			p.ConfigureKeys(pc.APIKeys, pc.KeySelection, pc.KeyCooldown)
+			registry.Register(p)
 			log.Printf("registered provider: %s (type: groq)", pc.Name)
 		case "mistral":
-			registry.Register(provider.NewMistralProvider(pc.Name, pc.APIKeyEnv, pc.Models, pc.Timeout))
+			p := provider.NewMistralProvider(pc.Name, pc.APIKeyEnv, pc.Models, pc.Timeout)
+			p.ConfigureKeys(pc.APIKeys, pc.KeySelection, pc.KeyCooldown)
+			registry.Register(p)
 			log.Printf("registered provider: %s (type: mistral)", pc.Name)
 		case "together":
-			registry.Register(provider.NewTogetherProvider(pc.Name, pc.APIKeyEnv, pc.Models, pc.Timeout))
+			p := provider.NewTogetherProvider(pc.Name, pc.APIKeyEnv, pc.Models, pc.Timeout)
+			p.ConfigureKeys(pc.APIKeys, pc.KeySelection, pc.KeyCooldown)
+			registry.Register(p)
 			log.Printf("registered provider: %s (type: together)", pc.Name)
 		case "bedrock":
 			registry.Register(provider.NewBedrockProvider(pc.Name, pc.Config["region"], pc.APIKeyEnv, pc.Config["secret_key_env"], pc.Models, pc.Timeout))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -169,18 +169,26 @@ type CORSConfig struct {
 }
 
 type ProviderConfig struct {
-	Name       string            `yaml:"name"`
-	Type       string            `yaml:"type"`
-	Enabled    bool              `yaml:"enabled"`
-	Default    bool              `yaml:"default"`
-	BaseURL    string            `yaml:"base_url"`
-	APIKeyEnv  string            `yaml:"api_key_env"`
-	Models     []string          `yaml:"models"`
-	Timeout    time.Duration     `yaml:"timeout"`
-	MaxRetries int               `yaml:"max_retries"`
-	APIVersion string            `yaml:"api_version"`
-	Config     map[string]string `yaml:"config"`
-	Region     string            `yaml:"region"`
+	Name         string               `yaml:"name"`
+	Type         string               `yaml:"type"`
+	Enabled      bool                 `yaml:"enabled"`
+	Default      bool                 `yaml:"default"`
+	BaseURL      string               `yaml:"base_url"`
+	APIKeyEnv    string               `yaml:"api_key_env"`
+	APIKeys      []ProviderAPIKey     `yaml:"api_keys"`
+	KeySelection string               `yaml:"key_selection"`
+	KeyCooldown  time.Duration        `yaml:"key_cooldown"`
+	Models       []string             `yaml:"models"`
+	Timeout      time.Duration        `yaml:"timeout"`
+	MaxRetries   int                  `yaml:"max_retries"`
+	APIVersion   string               `yaml:"api_version"`
+	Config       map[string]string    `yaml:"config"`
+	Region       string               `yaml:"region"`
+}
+
+type ProviderAPIKey struct {
+	Key    string `yaml:"key"`
+	Weight int    `yaml:"weight"`
 }
 
 type RegionConfig struct {
@@ -313,6 +321,9 @@ func Load(path string) (*Config, error) {
 	}
 
 	setDefaults(cfg)
+	if err := validateConfig(cfg); err != nil {
+		return nil, err
+	}
 	return cfg, nil
 }
 
@@ -392,6 +403,19 @@ func setDefaults(cfg *Config) {
 	if cfg.Budgets.Global.WarnAt == 0 {
 		cfg.Budgets.Global.WarnAt = 90
 	}
+	for i := range cfg.Providers {
+		if cfg.Providers[i].KeySelection == "" {
+			cfg.Providers[i].KeySelection = "round-robin"
+		}
+		if cfg.Providers[i].KeyCooldown == 0 {
+			cfg.Providers[i].KeyCooldown = 5 * time.Minute
+		}
+		for j := range cfg.Providers[i].APIKeys {
+			if cfg.Providers[i].APIKeys[j].Weight <= 0 {
+				cfg.Providers[i].APIKeys[j].Weight = 1
+			}
+		}
+	}
 
 	// Eval defaults
 	if cfg.Eval.Builtin.MinResponseTokens == 0 {
@@ -443,4 +467,18 @@ func (c *Config) FindTenantByAPIKey(apiKey string) *TenantMatch {
 		}
 	}
 	return match
+}
+
+func validateConfig(cfg *Config) error {
+	for _, provider := range cfg.Providers {
+		if provider.KeySelection != "" && provider.KeySelection != "round-robin" && provider.KeySelection != "random" && provider.KeySelection != "least-used" {
+			return fmt.Errorf("provider %q key_selection must be round-robin, random, or least-used", provider.Name)
+		}
+		for _, apiKey := range provider.APIKeys {
+			if apiKey.Weight < 1 {
+				return fmt.Errorf("provider %q api key weights must be at least 1", provider.Name)
+			}
+		}
+	}
+	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -910,3 +910,65 @@ federation:
 		t.Errorf("expected sync interval 1m, got %v", cfg.Federation.ControlPlane.SyncInterval)
 	}
 }
+
+func TestProviderAPIKeysParsingAndDefaults(t *testing.T) {
+	yamlData := `
+providers:
+  - name: "openai"
+    type: "openai"
+    enabled: true
+    api_keys:
+      - key: "sk-key-1"
+      - key: "sk-key-2"
+        weight: 2
+`
+	f, err := os.CreateTemp("", "aegisflow-api-keys-*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.WriteString(yamlData); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	cfg, err := Load(f.Name())
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+	provider := cfg.Providers[0]
+	if provider.KeySelection != "round-robin" {
+		t.Fatalf("expected default key selection round-robin, got %q", provider.KeySelection)
+	}
+	if provider.KeyCooldown != 5*time.Minute {
+		t.Fatalf("expected default key cooldown 5m, got %v", provider.KeyCooldown)
+	}
+	if provider.APIKeys[0].Weight != 1 || provider.APIKeys[1].Weight != 2 {
+		t.Fatalf("unexpected key weights: %+v", provider.APIKeys)
+	}
+}
+
+func TestProviderAPIKeysRejectInvalidSelection(t *testing.T) {
+	yamlData := `
+providers:
+  - name: "openai"
+    type: "openai"
+    enabled: true
+    key_selection: "invalid"
+    api_keys:
+      - key: "sk-key-1"
+`
+	f, err := os.CreateTemp("", "aegisflow-api-key-selection-*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.WriteString(yamlData); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	if _, err := Load(f.Name()); err == nil {
+		t.Fatal("expected invalid key selection to be rejected")
+	}
+}

--- a/internal/provider/azure_openai.go
+++ b/internal/provider/azure_openai.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/saivedant169/AegisFlow/internal/config"
 	"github.com/saivedant169/AegisFlow/pkg/types"
 )
 
@@ -25,6 +26,7 @@ type AzureOpenAIProvider struct {
 	apiVersion string
 	models     []string // model names map to deployment names
 	client     *http.Client
+	keys       *keyManager
 }
 
 func NewAzureOpenAIProvider(name, endpoint, apiKeyEnv, apiVersion string, models []string, timeout time.Duration) *AzureOpenAIProvider {
@@ -42,6 +44,7 @@ func NewAzureOpenAIProvider(name, endpoint, apiKeyEnv, apiVersion string, models
 		apiVersion: apiVersion,
 		models:     models,
 		client:     &http.Client{Timeout: timeout},
+		keys:       newKeyManager(apiKey, nil, "round-robin", 5*time.Minute),
 	}
 }
 
@@ -59,25 +62,11 @@ func (a *AzureOpenAIProvider) ChatCompletion(ctx context.Context, req *types.Cha
 		return nil, fmt.Errorf("marshaling request: %w", err)
 	}
 
-	url := a.buildURL(req.Model)
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	resp, err := a.doRequest(ctx, req.Model, body)
 	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
-	}
-
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("api-key", a.apiKey)
-
-	resp, err := a.client.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("sending request: %w", err)
+		return nil, err
 	}
 	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("provider returned status %d: %s", resp.StatusCode, string(respBody))
-	}
 
 	var result types.ChatCompletionResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
@@ -96,24 +85,9 @@ func (a *AzureOpenAIProvider) ChatCompletionStream(ctx context.Context, req *typ
 		return nil, fmt.Errorf("marshaling request: %w", err)
 	}
 
-	url := a.buildURL(req.Model)
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	resp, err := a.doRequest(ctx, req.Model, body)
 	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
-	}
-
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("api-key", a.apiKey)
-
-	resp, err := a.client.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("sending request: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		return nil, fmt.Errorf("provider returned status %d: %s", resp.StatusCode, string(respBody))
+		return nil, err
 	}
 
 	return resp.Body, nil
@@ -135,5 +109,44 @@ func (a *AzureOpenAIProvider) EstimateTokens(text string) int {
 }
 
 func (a *AzureOpenAIProvider) Healthy(ctx context.Context) bool {
-	return a.apiKey != ""
+	a.ensureKeyManager()
+	return a.keys != nil && a.keys.healthyCount() > 0
+}
+
+func (a *AzureOpenAIProvider) ConfigureKeys(apiKeys []config.ProviderAPIKey, selection string, cooldown time.Duration) {
+	a.keys = newKeyManager(a.apiKey, apiKeys, selection, cooldown)
+}
+
+func (a *AzureOpenAIProvider) doRequest(ctx context.Context, model string, body []byte) (*http.Response, error) {
+	a.ensureKeyManager()
+	key := a.keys.nextKey()
+	if key == nil {
+		return nil, fmt.Errorf("provider %s has no healthy API keys available", a.name)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, a.buildURL(model), bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("api-key", key.key)
+
+	resp, err := a.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("sending request: %w", err)
+	}
+	if resp.StatusCode == http.StatusOK {
+		return resp, nil
+	}
+
+	respBody, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	a.keys.reportStatus(a.name, key.key, resp.StatusCode)
+	return nil, fmt.Errorf("provider returned status %d: %s", resp.StatusCode, string(respBody))
+}
+
+func (a *AzureOpenAIProvider) ensureKeyManager() {
+	if a.keys == nil {
+		a.keys = newKeyManager(a.apiKey, nil, "round-robin", 5*time.Minute)
+	}
 }

--- a/internal/provider/key_health.go
+++ b/internal/provider/key_health.go
@@ -1,0 +1,168 @@
+package provider
+
+import (
+	"log"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/saivedant169/AegisFlow/internal/config"
+)
+
+type apiKeyState struct {
+	key             string
+	weight          int
+	useCount        int
+	permanentFailed bool
+	cooldownUntil   time.Time
+}
+
+type keyManager struct {
+	mu       sync.Mutex
+	keys     []*apiKeyState
+	strategy string
+	cooldown time.Duration
+	next     int
+	rng      *rand.Rand
+	now      func() time.Time
+}
+
+func newKeyManager(singleKey string, apiKeys []config.ProviderAPIKey, strategy string, cooldown time.Duration) *keyManager {
+	km := &keyManager{
+		strategy: strategy,
+		cooldown: cooldown,
+		rng:      rand.New(rand.NewSource(time.Now().UnixNano())),
+		now:      time.Now,
+	}
+	if km.cooldown <= 0 {
+		km.cooldown = 5 * time.Minute
+	}
+	for _, apiKey := range apiKeys {
+		if apiKey.Key == "" {
+			continue
+		}
+		weight := apiKey.Weight
+		if weight <= 0 {
+			weight = 1
+		}
+		km.keys = append(km.keys, &apiKeyState{key: apiKey.Key, weight: weight})
+	}
+	if len(km.keys) == 0 && singleKey != "" {
+		km.keys = append(km.keys, &apiKeyState{key: singleKey, weight: 1})
+	}
+	return km
+}
+
+func (km *keyManager) nextKey() *apiKeyState {
+	if km == nil {
+		return nil
+	}
+
+	km.mu.Lock()
+	defer km.mu.Unlock()
+
+	available := km.availableKeysLocked()
+	if len(available) == 0 {
+		return nil
+	}
+
+	var selected *apiKeyState
+	switch km.strategy {
+	case "random":
+		selected = km.pickRandomLocked(available)
+	case "least-used":
+		selected = km.pickLeastUsedLocked(available)
+	default:
+		selected = km.pickRoundRobinLocked(available)
+	}
+	if selected != nil {
+		selected.useCount++
+	}
+	return selected
+}
+
+func (km *keyManager) reportStatus(providerName, key string, status int) {
+	if km == nil || key == "" {
+		return
+	}
+
+	km.mu.Lock()
+	defer km.mu.Unlock()
+
+	for _, candidate := range km.keys {
+		if candidate.key != key {
+			continue
+		}
+		switch status {
+		case 401:
+			candidate.permanentFailed = true
+			log.Printf("provider %s: excluding API key permanently after 401", providerName)
+		case 429:
+			candidate.cooldownUntil = km.now().Add(km.cooldown)
+			log.Printf("provider %s: cooling down API key until %s after 429", providerName, candidate.cooldownUntil.Format(time.RFC3339))
+		}
+		return
+	}
+}
+
+func (km *keyManager) healthyCount() int {
+	if km == nil {
+		return 0
+	}
+	km.mu.Lock()
+	defer km.mu.Unlock()
+	return len(km.availableKeysLocked())
+}
+
+func (km *keyManager) availableKeysLocked() []*apiKeyState {
+	now := km.now()
+	available := make([]*apiKeyState, 0, len(km.keys))
+	for _, key := range km.keys {
+		if key.permanentFailed {
+			continue
+		}
+		if !key.cooldownUntil.IsZero() && key.cooldownUntil.After(now) {
+			continue
+		}
+		available = append(available, key)
+	}
+	return available
+}
+
+func (km *keyManager) weightedKeysLocked(keys []*apiKeyState) []*apiKeyState {
+	var weighted []*apiKeyState
+	for _, key := range keys {
+		for i := 0; i < key.weight; i++ {
+			weighted = append(weighted, key)
+		}
+	}
+	return weighted
+}
+
+func (km *keyManager) pickRoundRobinLocked(keys []*apiKeyState) *apiKeyState {
+	weighted := km.weightedKeysLocked(keys)
+	if len(weighted) == 0 {
+		return nil
+	}
+	selected := weighted[km.next%len(weighted)]
+	km.next++
+	return selected
+}
+
+func (km *keyManager) pickRandomLocked(keys []*apiKeyState) *apiKeyState {
+	weighted := km.weightedKeysLocked(keys)
+	if len(weighted) == 0 {
+		return nil
+	}
+	return weighted[km.rng.Intn(len(weighted))]
+}
+
+func (km *keyManager) pickLeastUsedLocked(keys []*apiKeyState) *apiKeyState {
+	selected := keys[0]
+	for _, key := range keys[1:] {
+		if key.useCount < selected.useCount {
+			selected = key
+		}
+	}
+	return selected
+}

--- a/internal/provider/key_health_test.go
+++ b/internal/provider/key_health_test.go
@@ -1,0 +1,112 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/saivedant169/AegisFlow/internal/config"
+	"github.com/saivedant169/AegisFlow/pkg/types"
+)
+
+func TestKeyManagerRoundRobinAndHealth(t *testing.T) {
+	km := newKeyManager("", []config.ProviderAPIKey{
+		{Key: "key-a", Weight: 1},
+		{Key: "key-b", Weight: 1},
+	}, "round-robin", time.Minute)
+	fixedNow := time.Now()
+	km.now = func() time.Time { return fixedNow }
+
+	if key := km.nextKey(); key == nil || key.key != "key-a" {
+		t.Fatalf("expected key-a first, got %#v", key)
+	}
+	if key := km.nextKey(); key == nil || key.key != "key-b" {
+		t.Fatalf("expected key-b second, got %#v", key)
+	}
+
+	km.reportStatus("openai", "key-a", http.StatusUnauthorized)
+	if key := km.nextKey(); key == nil || key.key != "key-b" {
+		t.Fatalf("expected key-b after key-a exclusion, got %#v", key)
+	}
+
+	km.reportStatus("openai", "key-b", http.StatusTooManyRequests)
+	if key := km.nextKey(); key != nil {
+		t.Fatalf("expected no key during cooldown, got %#v", key)
+	}
+
+	fixedNow = fixedNow.Add(2 * time.Minute)
+	if key := km.nextKey(); key == nil || key.key != "key-b" {
+		t.Fatalf("expected key-b after cooldown expiry, got %#v", key)
+	}
+}
+
+func TestKeyManagerRandomSelection(t *testing.T) {
+	km := newKeyManager("", []config.ProviderAPIKey{
+		{Key: "key-a", Weight: 1},
+		{Key: "key-b", Weight: 1},
+	}, "random", time.Minute)
+	seen := map[string]bool{}
+	for i := 0; i < 20; i++ {
+		key := km.nextKey()
+		if key == nil {
+			t.Fatal("expected available key")
+		}
+		seen[key.key] = true
+	}
+	if len(seen) != 2 {
+		t.Fatalf("expected both keys to be selectable, got %v", seen)
+	}
+}
+
+func TestOpenAIProviderRotatesAwayFromUnauthorizedKey(t *testing.T) {
+	var authHeaders []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeaders = append(authHeaders, r.Header.Get("Authorization"))
+		if r.Header.Get("Authorization") == "Bearer bad-key" {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(`{"error":"invalid key"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(types.ChatCompletionResponse{
+			ID:      "chatcmpl-ok",
+			Object:  "chat.completion",
+			Model:   "gpt-4o",
+			Choices: []types.Choice{{Index: 0, Message: types.Message{Role: "assistant", Content: "ok"}, FinishReason: "stop"}},
+			Usage:   types.Usage{PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2},
+		})
+	}))
+	defer srv.Close()
+
+	p := &OpenAIProvider{
+		name:    "openai-test",
+		baseURL: srv.URL,
+		client:  srv.Client(),
+	}
+	p.ConfigureKeys([]config.ProviderAPIKey{
+		{Key: "bad-key", Weight: 1},
+		{Key: "good-key", Weight: 1},
+	}, "round-robin", time.Minute)
+
+	req := &types.ChatCompletionRequest{
+		Model:    "gpt-4o",
+		Messages: []types.Message{{Role: "user", Content: "hello"}},
+	}
+
+	if _, err := p.ChatCompletion(context.Background(), req); err == nil {
+		t.Fatal("expected first request to fail with unauthorized key")
+	}
+	resp, err := p.ChatCompletion(context.Background(), req)
+	if err != nil {
+		t.Fatalf("expected second request to succeed, got %v", err)
+	}
+	if resp.Choices[0].Message.Content != "ok" {
+		t.Fatalf("unexpected response %q", resp.Choices[0].Message.Content)
+	}
+	if len(authHeaders) < 2 || authHeaders[0] != "Bearer bad-key" || authHeaders[1] != "Bearer good-key" {
+		t.Fatalf("expected key rotation from bad-key to good-key, got %v", authHeaders)
+	}
+}

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/saivedant169/AegisFlow/internal/config"
 	"github.com/saivedant169/AegisFlow/pkg/types"
 )
 
@@ -20,6 +21,7 @@ type OpenAIProvider struct {
 	models     []string
 	client     *http.Client
 	maxRetries int
+	keys       *keyManager
 }
 
 func NewOpenAIProvider(name, baseURL, apiKeyEnv string, models []string, timeout time.Duration, maxRetries int) *OpenAIProvider {
@@ -37,6 +39,7 @@ func NewOpenAIProvider(name, baseURL, apiKeyEnv string, models []string, timeout
 		models:     models,
 		client:     &http.Client{Timeout: timeout},
 		maxRetries: maxRetries,
+		keys:       newKeyManager(apiKey, nil, "round-robin", 5*time.Minute),
 	}
 }
 
@@ -50,24 +53,11 @@ func (o *OpenAIProvider) ChatCompletion(ctx context.Context, req *types.ChatComp
 		return nil, fmt.Errorf("marshaling request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, o.baseURL+"/chat/completions", bytes.NewReader(body))
+	resp, err := o.doRequest(ctx, body)
 	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
-	}
-
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+o.apiKey)
-
-	resp, err := o.client.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("sending request: %w", err)
+		return nil, err
 	}
 	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("provider returned status %d: %s", resp.StatusCode, string(respBody))
-	}
 
 	var result types.ChatCompletionResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
@@ -86,23 +76,9 @@ func (o *OpenAIProvider) ChatCompletionStream(ctx context.Context, req *types.Ch
 		return nil, fmt.Errorf("marshaling request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, o.baseURL+"/chat/completions", bytes.NewReader(body))
+	resp, err := o.doRequest(ctx, body)
 	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
-	}
-
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+o.apiKey)
-
-	resp, err := o.client.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("sending request: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		return nil, fmt.Errorf("provider returned status %d: %s", resp.StatusCode, string(respBody))
+		return nil, err
 	}
 
 	return resp.Body, nil
@@ -128,19 +104,63 @@ func (o *OpenAIProvider) EstimateTokens(text string) int {
 }
 
 func (o *OpenAIProvider) Healthy(ctx context.Context) bool {
-	if o.apiKey == "" {
+	o.ensureKeyManager()
+	if o.keys == nil || o.keys.healthyCount() == 0 {
+		return false
+	}
+	key := o.keys.nextKey()
+	if key == nil {
 		return false
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, o.baseURL+"/models", nil)
 	if err != nil {
 		return false
 	}
-	req.Header.Set("Authorization", "Bearer "+o.apiKey)
+	req.Header.Set("Authorization", "Bearer "+key.key)
 
 	resp, err := o.client.Do(req)
 	if err != nil {
 		return false
 	}
 	resp.Body.Close()
+	o.keys.reportStatus(o.name, key.key, resp.StatusCode)
 	return resp.StatusCode == http.StatusOK
+}
+
+func (o *OpenAIProvider) ConfigureKeys(apiKeys []config.ProviderAPIKey, selection string, cooldown time.Duration) {
+	o.keys = newKeyManager(o.apiKey, apiKeys, selection, cooldown)
+}
+
+func (o *OpenAIProvider) doRequest(ctx context.Context, body []byte) (*http.Response, error) {
+	o.ensureKeyManager()
+	key := o.keys.nextKey()
+	if key == nil {
+		return nil, fmt.Errorf("provider %s has no healthy API keys available", o.name)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, o.baseURL+"/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+key.key)
+
+	resp, err := o.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("sending request: %w", err)
+	}
+	if resp.StatusCode == http.StatusOK {
+		return resp, nil
+	}
+
+	respBody, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	o.keys.reportStatus(o.name, key.key, resp.StatusCode)
+	return nil, fmt.Errorf("provider returned status %d: %s", resp.StatusCode, string(respBody))
+}
+
+func (o *OpenAIProvider) ensureKeyManager() {
+	if o.keys == nil {
+		o.keys = newKeyManager(o.apiKey, nil, "round-robin", 5*time.Minute)
+	}
 }


### PR DESCRIPTION
Summary
- add `api_keys`, `key_selection`, and `key_cooldown` provider config support
- introduce a key manager with round-robin, random, and least-used selection
- exclude keys permanently on 401 and temporarily on 429, with tests for rotation and health behavior

Why
- a single upstream key is a single point of failure for rate limits, revocations, and routine key rotation

Validation
- `go test ./internal/config`
- `go test ./internal/provider`
- `go test ./cmd/aegisflow`

Closes #20