### PR TITLE
Add provider retry policy support

### DIFF
--- a/cmd/aegisflow/main.go
+++ b/cmd/aegisflow/main.go
@@ -412,7 +412,9 @@ func initProviders(cfg *config.Config, registry *provider.Registry) {
 			registry.Register(provider.NewMockProvider(pc.Name, latency))
 			log.Printf("registered provider: %s (type: mock, latency: %s)", pc.Name, latency)
 		case "openai":
-			registry.Register(provider.NewOpenAIProvider(pc.Name, pc.BaseURL, pc.APIKeyEnv, pc.Models, pc.Timeout, pc.MaxRetries))
+			p := provider.NewOpenAIProvider(pc.Name, pc.BaseURL, pc.APIKeyEnv, pc.Models, pc.Timeout, pc.MaxRetries)
+			p.ConfigureRetry(pc.Retry)
+			registry.Register(p)
 			log.Printf("registered provider: %s (type: openai, base_url: %s)", pc.Name, pc.BaseURL)
 		case "anthropic":
 			registry.Register(provider.NewAnthropicProvider(pc.Name, pc.BaseURL, pc.APIKeyEnv, pc.Models, pc.Timeout))
@@ -424,16 +426,24 @@ func initProviders(cfg *config.Config, registry *provider.Registry) {
 			registry.Register(provider.NewGeminiProvider(pc.Name, pc.APIKeyEnv, pc.Models, pc.Timeout))
 			log.Printf("registered provider: %s (type: gemini)", pc.Name)
 		case "azure_openai":
-			registry.Register(provider.NewAzureOpenAIProvider(pc.Name, pc.BaseURL, pc.APIKeyEnv, pc.APIVersion, pc.Models, pc.Timeout))
+			p := provider.NewAzureOpenAIProvider(pc.Name, pc.BaseURL, pc.APIKeyEnv, pc.APIVersion, pc.Models, pc.Timeout)
+			p.ConfigureRetry(pc.Retry)
+			registry.Register(p)
 			log.Printf("registered provider: %s (type: azure_openai, endpoint: %s)", pc.Name, pc.BaseURL)
 		case "groq":
-			registry.Register(provider.NewGroqProvider(pc.Name, pc.APIKeyEnv, pc.Models, pc.Timeout))
+			p := provider.NewGroqProvider(pc.Name, pc.APIKeyEnv, pc.Models, pc.Timeout)
+			p.ConfigureRetry(pc.Retry)
+			registry.Register(p)
 			log.Printf("registered provider: %s (type: groq)", pc.Name)
 		case "mistral":
-			registry.Register(provider.NewMistralProvider(pc.Name, pc.APIKeyEnv, pc.Models, pc.Timeout))
+			p := provider.NewMistralProvider(pc.Name, pc.APIKeyEnv, pc.Models, pc.Timeout)
+			p.ConfigureRetry(pc.Retry)
+			registry.Register(p)
 			log.Printf("registered provider: %s (type: mistral)", pc.Name)
 		case "together":
-			registry.Register(provider.NewTogetherProvider(pc.Name, pc.APIKeyEnv, pc.Models, pc.Timeout))
+			p := provider.NewTogetherProvider(pc.Name, pc.APIKeyEnv, pc.Models, pc.Timeout)
+			p.ConfigureRetry(pc.Retry)
+			registry.Register(p)
 			log.Printf("registered provider: %s (type: together)", pc.Name)
 		case "bedrock":
 			registry.Register(provider.NewBedrockProvider(pc.Name, pc.Config["region"], pc.APIKeyEnv, pc.Config["secret_key_env"], pc.Models, pc.Timeout))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -178,9 +178,19 @@ type ProviderConfig struct {
 	Models     []string          `yaml:"models"`
 	Timeout    time.Duration     `yaml:"timeout"`
 	MaxRetries int               `yaml:"max_retries"`
+	Retry      RetryConfig       `yaml:"retry"`
 	APIVersion string            `yaml:"api_version"`
 	Config     map[string]string `yaml:"config"`
 	Region     string            `yaml:"region"`
+}
+
+type RetryConfig struct {
+	MaxAttempts          int           `yaml:"max_attempts"`
+	InitialBackoff       time.Duration `yaml:"initial_backoff"`
+	MaxBackoff           time.Duration `yaml:"max_backoff"`
+	BackoffMultiplier    float64       `yaml:"backoff_multiplier"`
+	Jitter               bool          `yaml:"jitter"`
+	RetryableStatusCodes []int         `yaml:"retryable_status_codes"`
 }
 
 type RegionConfig struct {
@@ -313,6 +323,9 @@ func Load(path string) (*Config, error) {
 	}
 
 	setDefaults(cfg)
+	if err := validateConfig(cfg); err != nil {
+		return nil, err
+	}
 	return cfg, nil
 }
 
@@ -392,6 +405,23 @@ func setDefaults(cfg *Config) {
 	if cfg.Budgets.Global.WarnAt == 0 {
 		cfg.Budgets.Global.WarnAt = 90
 	}
+	for i := range cfg.Providers {
+		if cfg.Providers[i].Retry.MaxAttempts == 0 {
+			cfg.Providers[i].Retry.MaxAttempts = 1
+		}
+		if cfg.Providers[i].Retry.InitialBackoff == 0 {
+			cfg.Providers[i].Retry.InitialBackoff = 200 * time.Millisecond
+		}
+		if cfg.Providers[i].Retry.MaxBackoff == 0 {
+			cfg.Providers[i].Retry.MaxBackoff = 5 * time.Second
+		}
+		if cfg.Providers[i].Retry.BackoffMultiplier == 0 {
+			cfg.Providers[i].Retry.BackoffMultiplier = 2.0
+		}
+		if len(cfg.Providers[i].Retry.RetryableStatusCodes) == 0 {
+			cfg.Providers[i].Retry.RetryableStatusCodes = []int{429, 500, 502, 503, 504}
+		}
+	}
 
 	// Eval defaults
 	if cfg.Eval.Builtin.MinResponseTokens == 0 {
@@ -443,4 +473,13 @@ func (c *Config) FindTenantByAPIKey(apiKey string) *TenantMatch {
 		}
 	}
 	return match
+}
+
+func validateConfig(cfg *Config) error {
+	for _, provider := range cfg.Providers {
+		if provider.Retry.MaxAttempts < 1 {
+			return fmt.Errorf("provider %q retry.max_attempts must be at least 1", provider.Name)
+		}
+	}
+	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -910,3 +910,57 @@ federation:
 		t.Errorf("expected sync interval 1m, got %v", cfg.Federation.ControlPlane.SyncInterval)
 	}
 }
+
+func TestProviderRetryDefaults(t *testing.T) {
+	yamlData := `
+providers:
+  - name: "openai"
+    type: "openai"
+    enabled: true
+`
+	f, err := os.CreateTemp("", "aegisflow-retry-defaults-*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.WriteString(yamlData); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	cfg, err := Load(f.Name())
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+	retry := cfg.Providers[0].Retry
+	if retry.MaxAttempts != 1 || retry.InitialBackoff != 200*time.Millisecond || retry.MaxBackoff != 5*time.Second || retry.BackoffMultiplier != 2.0 {
+		t.Fatalf("unexpected retry defaults: %+v", retry)
+	}
+	if len(retry.RetryableStatusCodes) != 5 {
+		t.Fatalf("expected default retryable status codes, got %v", retry.RetryableStatusCodes)
+	}
+}
+
+func TestProviderRetryRejectsInvalidAttempts(t *testing.T) {
+	yamlData := `
+providers:
+  - name: "openai"
+    type: "openai"
+    enabled: true
+    retry:
+      max_attempts: -1
+`
+	f, err := os.CreateTemp("", "aegisflow-retry-invalid-*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.WriteString(yamlData); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	if _, err := Load(f.Name()); err == nil {
+		t.Fatal("expected invalid retry config to be rejected")
+	}
+}

--- a/internal/provider/azure_openai.go
+++ b/internal/provider/azure_openai.go
@@ -6,10 +6,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"time"
 
+	"github.com/saivedant169/AegisFlow/internal/config"
 	"github.com/saivedant169/AegisFlow/pkg/types"
 )
 
@@ -25,6 +27,8 @@ type AzureOpenAIProvider struct {
 	apiVersion string
 	models     []string // model names map to deployment names
 	client     *http.Client
+	retry      retryPolicy
+	sleep      func(time.Duration)
 }
 
 func NewAzureOpenAIProvider(name, endpoint, apiKeyEnv, apiVersion string, models []string, timeout time.Duration) *AzureOpenAIProvider {
@@ -42,6 +46,8 @@ func NewAzureOpenAIProvider(name, endpoint, apiKeyEnv, apiVersion string, models
 		apiVersion: apiVersion,
 		models:     models,
 		client:     &http.Client{Timeout: timeout},
+		retry:      newRetryPolicy(config.RetryConfig{MaxAttempts: 1}),
+		sleep:      time.Sleep,
 	}
 }
 
@@ -59,25 +65,11 @@ func (a *AzureOpenAIProvider) ChatCompletion(ctx context.Context, req *types.Cha
 		return nil, fmt.Errorf("marshaling request: %w", err)
 	}
 
-	url := a.buildURL(req.Model)
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	resp, err := a.doRequest(ctx, req.Model, body)
 	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
-	}
-
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("api-key", a.apiKey)
-
-	resp, err := a.client.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("sending request: %w", err)
+		return nil, err
 	}
 	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("provider returned status %d: %s", resp.StatusCode, string(respBody))
-	}
 
 	var result types.ChatCompletionResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
@@ -96,24 +88,9 @@ func (a *AzureOpenAIProvider) ChatCompletionStream(ctx context.Context, req *typ
 		return nil, fmt.Errorf("marshaling request: %w", err)
 	}
 
-	url := a.buildURL(req.Model)
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	resp, err := a.doRequest(ctx, req.Model, body)
 	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
-	}
-
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("api-key", a.apiKey)
-
-	resp, err := a.client.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("sending request: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		return nil, fmt.Errorf("provider returned status %d: %s", resp.StatusCode, string(respBody))
+		return nil, err
 	}
 
 	return resp.Body, nil
@@ -136,4 +113,46 @@ func (a *AzureOpenAIProvider) EstimateTokens(text string) int {
 
 func (a *AzureOpenAIProvider) Healthy(ctx context.Context) bool {
 	return a.apiKey != ""
+}
+
+func (a *AzureOpenAIProvider) ConfigureRetry(cfg config.RetryConfig) {
+	a.retry = newRetryPolicy(cfg)
+}
+
+func (a *AzureOpenAIProvider) doRequest(ctx context.Context, model string, body []byte) (*http.Response, error) {
+	attempts := a.retry.maxAttempts
+	if attempts <= 0 {
+		attempts = 1
+	}
+
+	for attempt := 1; attempt <= attempts; attempt++ {
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, a.buildURL(model), bytes.NewReader(body))
+		if err != nil {
+			return nil, fmt.Errorf("creating request: %w", err)
+		}
+		httpReq.Header.Set("Content-Type", "application/json")
+		httpReq.Header.Set("api-key", a.apiKey)
+
+		resp, err := a.client.Do(httpReq)
+		if err != nil {
+			return nil, fmt.Errorf("sending request: %w", err)
+		}
+		if resp.StatusCode == http.StatusOK {
+			return resp, nil
+		}
+
+		respBody, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		statusErr := &HTTPStatusError{StatusCode: resp.StatusCode, Body: string(respBody), Header: resp.Header.Clone()}
+		if attempt < attempts && a.retry.shouldRetry(resp.StatusCode) {
+			delay := a.retry.delayForAttempt(attempt, resp.Header)
+			log.Printf("provider %s: retry attempt %d/%d after %s due to status %d", a.name, attempt+1, attempts, delay, resp.StatusCode)
+			a.sleep(delay)
+			continue
+		}
+		return nil, statusErr
+	}
+
+	return nil, fmt.Errorf("provider %s exhausted retries", a.name)
 }

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -6,10 +6,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"time"
 
+	"github.com/saivedant169/AegisFlow/internal/config"
 	"github.com/saivedant169/AegisFlow/pkg/types"
 )
 
@@ -20,6 +22,8 @@ type OpenAIProvider struct {
 	models     []string
 	client     *http.Client
 	maxRetries int
+	retry      retryPolicy
+	sleep      func(time.Duration)
 }
 
 func NewOpenAIProvider(name, baseURL, apiKeyEnv string, models []string, timeout time.Duration, maxRetries int) *OpenAIProvider {
@@ -37,6 +41,8 @@ func NewOpenAIProvider(name, baseURL, apiKeyEnv string, models []string, timeout
 		models:     models,
 		client:     &http.Client{Timeout: timeout},
 		maxRetries: maxRetries,
+		retry:      newRetryPolicy(config.RetryConfig{MaxAttempts: 1}),
+		sleep:      time.Sleep,
 	}
 }
 
@@ -50,24 +56,11 @@ func (o *OpenAIProvider) ChatCompletion(ctx context.Context, req *types.ChatComp
 		return nil, fmt.Errorf("marshaling request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, o.baseURL+"/chat/completions", bytes.NewReader(body))
+	resp, err := o.doRequest(ctx, body)
 	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
-	}
-
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+o.apiKey)
-
-	resp, err := o.client.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("sending request: %w", err)
+		return nil, err
 	}
 	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("provider returned status %d: %s", resp.StatusCode, string(respBody))
-	}
 
 	var result types.ChatCompletionResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
@@ -86,23 +79,9 @@ func (o *OpenAIProvider) ChatCompletionStream(ctx context.Context, req *types.Ch
 		return nil, fmt.Errorf("marshaling request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, o.baseURL+"/chat/completions", bytes.NewReader(body))
+	resp, err := o.doRequest(ctx, body)
 	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
-	}
-
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+o.apiKey)
-
-	resp, err := o.client.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("sending request: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		return nil, fmt.Errorf("provider returned status %d: %s", resp.StatusCode, string(respBody))
+		return nil, err
 	}
 
 	return resp.Body, nil
@@ -143,4 +122,46 @@ func (o *OpenAIProvider) Healthy(ctx context.Context) bool {
 	}
 	resp.Body.Close()
 	return resp.StatusCode == http.StatusOK
+}
+
+func (o *OpenAIProvider) ConfigureRetry(cfg config.RetryConfig) {
+	o.retry = newRetryPolicy(cfg)
+}
+
+func (o *OpenAIProvider) doRequest(ctx context.Context, body []byte) (*http.Response, error) {
+	attempts := o.retry.maxAttempts
+	if attempts <= 0 {
+		attempts = 1
+	}
+
+	for attempt := 1; attempt <= attempts; attempt++ {
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, o.baseURL+"/chat/completions", bytes.NewReader(body))
+		if err != nil {
+			return nil, fmt.Errorf("creating request: %w", err)
+		}
+		httpReq.Header.Set("Content-Type", "application/json")
+		httpReq.Header.Set("Authorization", "Bearer "+o.apiKey)
+
+		resp, err := o.client.Do(httpReq)
+		if err != nil {
+			return nil, fmt.Errorf("sending request: %w", err)
+		}
+		if resp.StatusCode == http.StatusOK {
+			return resp, nil
+		}
+
+		respBody, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		statusErr := &HTTPStatusError{StatusCode: resp.StatusCode, Body: string(respBody), Header: resp.Header.Clone()}
+		if attempt < attempts && o.retry.shouldRetry(resp.StatusCode) {
+			delay := o.retry.delayForAttempt(attempt, resp.Header)
+			log.Printf("provider %s: retry attempt %d/%d after %s due to status %d", o.name, attempt+1, attempts, delay, resp.StatusCode)
+			o.sleep(delay)
+			continue
+		}
+		return nil, statusErr
+	}
+
+	return nil, fmt.Errorf("provider %s exhausted retries", o.name)
 }

--- a/internal/provider/retry.go
+++ b/internal/provider/retry.go
@@ -1,0 +1,107 @@
+package provider
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/saivedant169/AegisFlow/internal/config"
+)
+
+type HTTPStatusError struct {
+	StatusCode int
+	Body       string
+	Header     http.Header
+}
+
+func (e *HTTPStatusError) Error() string {
+	return fmt.Sprintf("provider returned status %d: %s", e.StatusCode, e.Body)
+}
+
+type retryPolicy struct {
+	maxAttempts int
+	initial     time.Duration
+	max         time.Duration
+	multiplier  float64
+	jitter      bool
+	retryable   map[int]struct{}
+	rng         *rand.Rand
+}
+
+func newRetryPolicy(cfg config.RetryConfig) retryPolicy {
+	policy := retryPolicy{
+		maxAttempts: cfg.MaxAttempts,
+		initial:     cfg.InitialBackoff,
+		max:         cfg.MaxBackoff,
+		multiplier:  cfg.BackoffMultiplier,
+		jitter:      cfg.Jitter,
+		retryable:   make(map[int]struct{}, len(cfg.RetryableStatusCodes)),
+		rng:         rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+	if policy.maxAttempts <= 0 {
+		policy.maxAttempts = 1
+	}
+	if policy.initial <= 0 {
+		policy.initial = 200 * time.Millisecond
+	}
+	if policy.max <= 0 {
+		policy.max = 5 * time.Second
+	}
+	if policy.multiplier <= 0 {
+		policy.multiplier = 2.0
+	}
+	for _, code := range cfg.RetryableStatusCodes {
+		policy.retryable[code] = struct{}{}
+	}
+	if len(policy.retryable) == 0 {
+		for _, code := range []int{429, 500, 502, 503, 504} {
+			policy.retryable[code] = struct{}{}
+		}
+	}
+	return policy
+}
+
+func (p retryPolicy) shouldRetry(status int) bool {
+	if p.maxAttempts <= 1 {
+		return false
+	}
+	_, ok := p.retryable[status]
+	return ok
+}
+
+func (p retryPolicy) delayForAttempt(attempt int, header http.Header) time.Duration {
+	if retryAfter := parseRetryAfter(header.Get("Retry-After")); retryAfter > 0 {
+		return retryAfter
+	}
+
+	backoff := float64(p.initial)
+	if attempt > 1 {
+		backoff *= math.Pow(p.multiplier, float64(attempt-1))
+	}
+	delay := time.Duration(backoff)
+	if delay > p.max {
+		delay = p.max
+	}
+	if p.jitter && delay > 0 {
+		delay = time.Duration(p.rng.Int63n(int64(delay) + 1))
+	}
+	return delay
+}
+
+func parseRetryAfter(value string) time.Duration {
+	if value == "" {
+		return 0
+	}
+	if seconds, err := strconv.Atoi(value); err == nil && seconds >= 0 {
+		return time.Duration(seconds) * time.Second
+	}
+	if when, err := http.ParseTime(value); err == nil {
+		if delay := time.Until(when); delay > 0 {
+			return delay
+		}
+	}
+	return 0
+}

--- a/internal/provider/retry_test.go
+++ b/internal/provider/retry_test.go
@@ -1,0 +1,87 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/saivedant169/AegisFlow/internal/config"
+	"github.com/saivedant169/AegisFlow/pkg/types"
+)
+
+func TestRetryPolicyDelayUsesRetryAfter(t *testing.T) {
+	policy := newRetryPolicy(config.RetryConfig{MaxAttempts: 3, RetryableStatusCodes: []int{429}})
+	header := http.Header{}
+	header.Set("Retry-After", "1")
+	if got := policy.delayForAttempt(1, header); got != time.Second {
+		t.Fatalf("expected 1s delay, got %v", got)
+	}
+}
+
+func TestRetryPolicyJitterStaysWithinBounds(t *testing.T) {
+	policy := newRetryPolicy(config.RetryConfig{
+		MaxAttempts:       3,
+		InitialBackoff:    200 * time.Millisecond,
+		MaxBackoff:        5 * time.Second,
+		BackoffMultiplier: 2.0,
+		Jitter:            true,
+	})
+	for i := 0; i < 20; i++ {
+		delay := policy.delayForAttempt(2, http.Header{})
+		if delay < 0 || delay > 400*time.Millisecond {
+			t.Fatalf("expected jittered delay within [0, 400ms], got %v", delay)
+		}
+	}
+}
+
+func TestOpenAIProviderRetriesWithRetryAfter(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			w.Write([]byte(`{"error":"rate limited"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(types.ChatCompletionResponse{
+			ID:      "chatcmpl-test",
+			Object:  "chat.completion",
+			Model:   "gpt-4o",
+			Choices: []types.Choice{{Index: 0, Message: types.Message{Role: "assistant", Content: "retry success"}, FinishReason: "stop"}},
+			Usage:   types.Usage{PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2},
+		})
+	}))
+	defer srv.Close()
+
+	p := &OpenAIProvider{
+		name:    "openai-test",
+		baseURL: srv.URL,
+		apiKey:  "test-key",
+		client:  srv.Client(),
+	}
+	p.ConfigureRetry(config.RetryConfig{MaxAttempts: 2, RetryableStatusCodes: []int{429}})
+	var slept []time.Duration
+	p.sleep = func(d time.Duration) { slept = append(slept, d) }
+
+	resp, err := p.ChatCompletion(context.Background(), &types.ChatCompletionRequest{
+		Model:    "gpt-4o",
+		Messages: []types.Message{{Role: "user", Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Choices[0].Message.Content != "retry success" {
+		t.Fatalf("unexpected response %q", resp.Choices[0].Message.Content)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 upstream calls, got %d", calls)
+	}
+	if len(slept) != 1 || slept[0] != time.Second {
+		t.Fatalf("expected retry-after sleep of 1s, got %v", slept)
+	}
+}


### PR DESCRIPTION
Summary
- add per-provider retry configuration with backoff, multiplier, jitter, and retryable status codes
- respect upstream `Retry-After` headers when retrying OpenAI-compatible providers
- add policy and provider tests for delay calculation, jitter bounds, and retry execution

Why
- transient upstream failures should be retried before the router spends fallback capacity on another provider

Validation
- `go test ./internal/config`
- `go test ./internal/provider`
- `go test ./cmd/aegisflow`

Closes #19