### PR TITLE
Add gzip compression support for gateway payloads

### DIFF
--- a/cmd/aegisflow/main.go
+++ b/cmd/aegisflow/main.go
@@ -203,6 +203,7 @@ func main() {
 		budgetCheckFn = budgetMgr.CheckFunc()
 	}
 	handler := gateway.NewHandler(registry, rt, pe, ut, responseCache, wh, pgStore, analyticsCollector, cfg.Server.MaxBodySize, recordSpendFn, budgetCheckFn)
+	handler.SetCompression(cfg.Compression.Enabled, cfg.Compression.MinSizeBytes)
 
 	// Eval hooks
 	if cfg.Eval.Enabled {

--- a/configs/aegisflow.yaml
+++ b/configs/aegisflow.yaml
@@ -7,6 +7,10 @@ server:
   graceful_shutdown: 10s
   max_body_size: 10485760
 
+compression:
+  enabled: false
+  min_size_bytes: 1024
+
 providers:
   - name: "mock"
     type: "mock"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,24 +11,30 @@ import (
 )
 
 type Config struct {
-	Server    ServerConfig     `yaml:"server"`
-	Providers []ProviderConfig `yaml:"providers"`
-	Routes    []RouteConfig    `yaml:"routes"`
-	Tenants   []TenantConfig   `yaml:"tenants"`
-	RateLimit RateLimitConfig  `yaml:"rate_limit"`
-	Policies  PoliciesConfig   `yaml:"policies"`
-	Telemetry TelemetryConfig  `yaml:"telemetry"`
-	Logging   LoggingConfig    `yaml:"logging"`
-	Cache     CacheConfig      `yaml:"cache"`
-	Webhook   WebhookConfig    `yaml:"webhook"`
-	Database  DatabaseConfig   `yaml:"database"`
-	Admin     AdminConfig      `yaml:"admin"`
-	Aliases   AliasConfig      `yaml:"aliases"`
-	Transform TransformConfig  `yaml:"transform"`
-	Analytics AnalyticsConfig  `yaml:"analytics"`
-	Budgets   BudgetsConfig    `yaml:"budgets"`
-	Eval       EvalConfig       `yaml:"eval"`
-	Federation FederationConfig `yaml:"federation"`
+	Server      ServerConfig      `yaml:"server"`
+	Providers   []ProviderConfig  `yaml:"providers"`
+	Routes      []RouteConfig     `yaml:"routes"`
+	Tenants     []TenantConfig    `yaml:"tenants"`
+	RateLimit   RateLimitConfig   `yaml:"rate_limit"`
+	Policies    PoliciesConfig    `yaml:"policies"`
+	Telemetry   TelemetryConfig   `yaml:"telemetry"`
+	Logging     LoggingConfig     `yaml:"logging"`
+	Cache       CacheConfig       `yaml:"cache"`
+	Webhook     WebhookConfig     `yaml:"webhook"`
+	Database    DatabaseConfig    `yaml:"database"`
+	Admin       AdminConfig       `yaml:"admin"`
+	Aliases     AliasConfig       `yaml:"aliases"`
+	Transform   TransformConfig   `yaml:"transform"`
+	Analytics   AnalyticsConfig   `yaml:"analytics"`
+	Budgets     BudgetsConfig     `yaml:"budgets"`
+	Eval        EvalConfig        `yaml:"eval"`
+	Compression CompressionConfig `yaml:"compression"`
+	Federation  FederationConfig  `yaml:"federation"`
+}
+
+type CompressionConfig struct {
+	Enabled      bool `yaml:"enabled"`
+	MinSizeBytes int  `yaml:"min_size_bytes"`
 }
 
 type FederationConfig struct {
@@ -358,6 +364,9 @@ func setDefaults(cfg *Config) {
 	}
 	if cfg.Cache.MaxSize == 0 {
 		cfg.Cache.MaxSize = 1000
+	}
+	if cfg.Compression.MinSizeBytes == 0 {
+		cfg.Compression.MinSizeBytes = 1024
 	}
 	if cfg.Analytics.RetentionHours == 0 {
 		cfg.Analytics.RetentionHours = 48

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -14,6 +14,9 @@ func TestLoadConfig(t *testing.T) {
 server:
   port: 9090
   admin_port: 9091
+compression:
+  enabled: true
+  min_size_bytes: 256
 providers:
   - name: "mock"
     type: "mock"
@@ -68,6 +71,9 @@ tenants:
 	}
 	if cfg.Server.Host != "0.0.0.0" {
 		t.Errorf("expected default host '0.0.0.0', got '%s'", cfg.Server.Host)
+	}
+	if !cfg.Compression.Enabled || cfg.Compression.MinSizeBytes != 256 {
+		t.Errorf("expected compression config {true,256}, got {%v,%d}", cfg.Compression.Enabled, cfg.Compression.MinSizeBytes)
 	}
 }
 
@@ -316,6 +322,9 @@ func TestSetDefaultsAllValues(t *testing.T) {
 	}
 	if cfg.Cache.MaxSize != 1000 {
 		t.Errorf("expected cache max size 1000, got %d", cfg.Cache.MaxSize)
+	}
+	if cfg.Compression.MinSizeBytes != 1024 {
+		t.Errorf("expected compression min size 1024, got %d", cfg.Compression.MinSizeBytes)
 	}
 
 	// Analytics

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -1,6 +1,8 @@
 package gateway
 
 import (
+	"bytes"
+	"compress/gzip"
 	"encoding/json"
 	"io"
 	"log"
@@ -24,15 +26,15 @@ import (
 )
 
 type Handler struct {
-	registry    *provider.Registry
-	router      *router.Router
-	policy      *policy.Engine
-	usage       *usage.Tracker
-	cache       cache.Cache
-	webhook     *webhook.Notifier
-	store       *storage.PostgresStore
-	dbQueue     chan storage.UsageEvent
-	analytics   *analytics.Collector
+	registry       *provider.Registry
+	router         *router.Router
+	policy         *policy.Engine
+	usage          *usage.Tracker
+	cache          cache.Cache
+	webhook        *webhook.Notifier
+	store          *storage.PostgresStore
+	dbQueue        chan storage.UsageEvent
+	analytics      *analytics.Collector
 	maxBodySize    int64
 	recordSpend    func(tenantID, model string, cost float64)
 	budgetCheck    func(tenantID, model string) (bool, []string, string)
@@ -41,11 +43,22 @@ type Handler struct {
 	evalLatencyMul float64
 	evalWebhook    *eval.WebhookEvaluator
 	auditLog       func(actor, actorRole, action, resource, detail, tenantID, model string)
+	compressBody   bool
+	compressMinB   int
 }
 
 // SetAuditLogger sets the audit logging function on the handler.
 func (h *Handler) SetAuditLogger(logFn func(actor, actorRole, action, resource, detail, tenantID, model string)) {
 	h.auditLog = logFn
+}
+
+// SetCompression configures gzip compression for non-streaming JSON responses.
+func (h *Handler) SetCompression(enabled bool, minSizeBytes int) {
+	h.compressBody = enabled
+	if minSizeBytes <= 0 {
+		minSizeBytes = 1024
+	}
+	h.compressMinB = minSizeBytes
 }
 
 const (
@@ -58,6 +71,7 @@ func NewHandler(registry *provider.Registry, rt *router.Router, pe *policy.Engin
 		maxBodySize = defaultMaxBodySize
 	}
 	h := &Handler{registry: registry, router: rt, policy: pe, usage: ut, cache: c, webhook: wh, store: store, analytics: ac, maxBodySize: maxBodySize, recordSpend: recordSpend, budgetCheck: budgetCheck}
+	h.compressMinB = 1024
 	if store != nil {
 		h.dbQueue = make(chan storage.UsageEvent, dbQueueSize)
 		go h.dbWorker()
@@ -93,17 +107,27 @@ func (h *Handler) SetEval(builtinEnabled bool, minTokens int, latencyMul float64
 func (h *Handler) ChatCompletion(w http.ResponseWriter, r *http.Request) {
 	startTime := time.Now()
 	var req types.ChatCompletionRequest
-	if err := json.NewDecoder(io.LimitReader(r.Body, h.maxBodySize)).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_request", "failed to parse request body")
+	body := io.LimitReader(r.Body, h.maxBodySize)
+	if strings.Contains(strings.ToLower(r.Header.Get("Content-Encoding")), "gzip") {
+		gzr, err := gzip.NewReader(body)
+		if err != nil {
+			h.writeError(w, r, http.StatusBadRequest, "invalid_request", "failed to parse request body")
+			return
+		}
+		defer gzr.Close()
+		body = io.LimitReader(gzr, h.maxBodySize)
+	}
+	if err := json.NewDecoder(body).Decode(&req); err != nil {
+		h.writeError(w, r, http.StatusBadRequest, "invalid_request", "failed to parse request body")
 		return
 	}
 
 	if req.Model == "" {
-		writeError(w, http.StatusBadRequest, "invalid_request", "model is required")
+		h.writeError(w, r, http.StatusBadRequest, "invalid_request", "model is required")
 		return
 	}
 	if len(req.Messages) == 0 {
-		writeError(w, http.StatusBadRequest, "invalid_request", "messages is required")
+		h.writeError(w, r, http.StatusBadRequest, "invalid_request", "messages is required")
 		return
 	}
 
@@ -117,7 +141,7 @@ func (h *Handler) ChatCompletion(w http.ResponseWriter, r *http.Request) {
 		allowed, warnings, blockMsg := h.budgetCheck(tenantID, req.Model)
 		if !allowed {
 			h.recordAnalytics(tenantID, req.Model, "", http.StatusTooManyRequests, startTime, 0)
-			writeError(w, http.StatusTooManyRequests, "budget_exceeded", blockMsg)
+			h.writeError(w, r, http.StatusTooManyRequests, "budget_exceeded", blockMsg)
 			return
 		}
 		for _, warning := range warnings {
@@ -139,7 +163,7 @@ func (h *Handler) ChatCompletion(w http.ResponseWriter, r *http.Request) {
 					}
 					h.auditLog("system", "system", "policy.block", "policy:"+v.PolicyName, `{"message":"`+v.Message+`","prompt":"`+prompt+`"}`, tenantID, req.Model)
 				}
-				writeError(w, http.StatusForbidden, "policy_violation", policy.FormatViolation(v))
+				h.writeError(w, r, http.StatusForbidden, "policy_violation", policy.FormatViolation(v))
 				return
 			}
 			h.fireWebhook("policy_warning", v.PolicyName, string(v.Action), tenantID, req.Model, v.Message)
@@ -157,9 +181,8 @@ func (h *Handler) ChatCompletion(w http.ResponseWriter, r *http.Request) {
 		cacheKey := cache.BuildKey(tenantID, req.Model, req.Messages)
 		if cached, ok := h.cache.Get(cacheKey); ok {
 			log.Printf("cache hit: %s", cacheKey[:20])
-			w.Header().Set("Content-Type", "application/json")
 			w.Header().Set("X-AegisFlow-Cache", "HIT")
-			json.NewEncoder(w).Encode(cached)
+			h.writeJSON(w, r, http.StatusOK, cached)
 			return
 		}
 	}
@@ -167,7 +190,7 @@ func (h *Handler) ChatCompletion(w http.ResponseWriter, r *http.Request) {
 	routed, err := h.router.RouteWithProvider(r.Context(), &req)
 	if err != nil {
 		h.recordAnalytics(tenantID, req.Model, "", http.StatusBadGateway, startTime, 0)
-		writeError(w, http.StatusBadGateway, "provider_error", err.Error())
+		h.writeError(w, r, http.StatusBadGateway, "provider_error", err.Error())
 		return
 	}
 	resp := routed.Response
@@ -182,7 +205,7 @@ func (h *Handler) ChatCompletion(w http.ResponseWriter, r *http.Request) {
 				if h.auditLog != nil {
 					h.auditLog("system", "system", "policy.block", "policy:"+v.PolicyName, `{"message":"`+v.Message+`","phase":"output"}`, tenantID, req.Model)
 				}
-				writeError(w, http.StatusForbidden, "policy_violation", policy.FormatViolation(v))
+				h.writeError(w, r, http.StatusForbidden, "policy_violation", policy.FormatViolation(v))
 				return
 			}
 			log.Printf("policy warning (output): %s", policy.FormatViolation(v))
@@ -246,21 +269,20 @@ func (h *Handler) ChatCompletion(w http.ResponseWriter, r *http.Request) {
 	// Record analytics data point
 	h.recordAnalytics(tenantID, req.Model, providerName, 200, startTime, int64(resp.Usage.TotalTokens), qualityScore)
 
-	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("X-AegisFlow-Cache", "MISS")
-	json.NewEncoder(w).Encode(resp)
+	h.writeJSON(w, r, http.StatusOK, resp)
 }
 
 func (h *Handler) handleStream(w http.ResponseWriter, r *http.Request, req *types.ChatCompletionRequest, tenantID string) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
-		writeError(w, http.StatusInternalServerError, "server_error", "streaming not supported")
+		h.writeError(w, r, http.StatusInternalServerError, "server_error", "streaming not supported")
 		return
 	}
 
 	stream, err := h.router.RouteStream(r.Context(), req)
 	if err != nil {
-		writeError(w, http.StatusBadGateway, "provider_error", err.Error())
+		h.writeError(w, r, http.StatusBadGateway, "provider_error", err.Error())
 		return
 	}
 	defer stream.Close()
@@ -325,8 +347,7 @@ func (h *Handler) ListModels(w http.ResponseWriter, r *http.Request) {
 		Object: "list",
 		Data:   models,
 	}
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(resp)
+	h.writeJSON(w, r, http.StatusOK, resp)
 }
 
 func (h *Handler) recordAnalytics(tenantID, model, providerName string, statusCode int, startTime time.Time, tokens int64, qualityScore ...int) {
@@ -370,8 +391,35 @@ func extractContent(messages []types.Message) string {
 	return strings.Join(parts, " ")
 }
 
-func writeError(w http.ResponseWriter, code int, errType, message string) {
+func acceptsGzip(r *http.Request) bool {
+	return strings.Contains(strings.ToLower(r.Header.Get("Accept-Encoding")), "gzip")
+}
+
+func (h *Handler) writeJSON(w http.ResponseWriter, r *http.Request, status int, payload any) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		http.Error(w, `{"error":{"message":"failed to encode response","type":"server_error"}}`, http.StatusInternalServerError)
+		return
+	}
+
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(code)
-	json.NewEncoder(w).Encode(types.NewErrorResponse(code, errType, message))
+	w.Header().Set("Vary", "Accept-Encoding")
+
+	if h.compressBody && acceptsGzip(r) && len(body) >= h.compressMinB {
+		var compressed bytes.Buffer
+		gzw := gzip.NewWriter(&compressed)
+		if _, err := gzw.Write(body); err == nil && gzw.Close() == nil {
+			w.Header().Set("Content-Encoding", "gzip")
+			w.WriteHeader(status)
+			w.Write(compressed.Bytes())
+			return
+		}
+	}
+
+	w.WriteHeader(status)
+	w.Write(body)
+}
+
+func (h *Handler) writeError(w http.ResponseWriter, r *http.Request, code int, errType, message string) {
+	h.writeJSON(w, r, code, types.NewErrorResponse(code, errType, message))
 }

--- a/internal/gateway/handler_test.go
+++ b/internal/gateway/handler_test.go
@@ -2,8 +2,10 @@ package gateway
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -97,6 +99,98 @@ func TestChatCompletionMissingMessages(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestChatCompletionGzipRequestBody(t *testing.T) {
+	h := setupTestHandler()
+
+	var body bytes.Buffer
+	gzw := gzip.NewWriter(&body)
+	if _, err := gzw.Write([]byte(`{"model":"mock","messages":[{"role":"user","content":"hello"}]}`)); err != nil {
+		t.Fatalf("failed to write gzipped request: %v", err)
+	}
+	if err := gzw.Close(); err != nil {
+		t.Fatalf("failed to close gzip writer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body.Bytes()))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Encoding", "gzip")
+	w := httptest.NewRecorder()
+
+	h.ChatCompletion(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestChatCompletionGzipResponse(t *testing.T) {
+	h := setupTestHandler()
+	h.SetCompression(true, 1)
+
+	reqBody := types.ChatCompletionRequest{
+		Model:    "mock",
+		Messages: []types.Message{{Role: "user", Content: "compress me"}},
+	}
+	body, _ := json.Marshal(reqBody)
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept-Encoding", "gzip")
+	w := httptest.NewRecorder()
+
+	h.ChatCompletion(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if w.Header().Get("Content-Encoding") != "gzip" {
+		t.Fatalf("expected gzip response, got %q", w.Header().Get("Content-Encoding"))
+	}
+
+	gzr, err := gzip.NewReader(bytes.NewReader(w.Body.Bytes()))
+	if err != nil {
+		t.Fatalf("failed to create gzip reader: %v", err)
+	}
+	defer gzr.Close()
+
+	data, err := io.ReadAll(gzr)
+	if err != nil {
+		t.Fatalf("failed to read gzipped response: %v", err)
+	}
+
+	var resp types.ChatCompletionResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		t.Fatalf("failed to decode gzipped response: %v", err)
+	}
+	if len(resp.Choices) != 1 {
+		t.Fatalf("expected 1 choice, got %d", len(resp.Choices))
+	}
+}
+
+func TestChatCompletionStreamDisablesCompression(t *testing.T) {
+	h := setupTestHandler()
+	h.SetCompression(true, 1)
+
+	reqBody := types.ChatCompletionRequest{
+		Model:    "mock",
+		Messages: []types.Message{{Role: "user", Content: "stream me"}},
+		Stream:   true,
+	}
+	body, _ := json.Marshal(reqBody)
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept-Encoding", "gzip")
+	w := httptest.NewRecorder()
+
+	h.ChatCompletion(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if got := w.Header().Get("Content-Encoding"); got != "" {
+		t.Fatalf("expected uncompressed stream, got %q", got)
 	}
 }
 


### PR DESCRIPTION
Summary
- add gateway compression config with an enable flag and minimum response size threshold
- decompress gzipped chat-completion request bodies and gzip eligible JSON responses when the client opts in
- keep streaming responses uncompressed and add tests for request, response, and stream paths

Why
- large chat payloads should not pay full bandwidth cost when both the client and gateway can negotiate gzip

Validation
- `go test ./internal/config`
- `go test ./internal/gateway`
- `go test ./cmd/aegisflow`

Closes #16