### PR TITLE
Add data plane names to the live request feed

### DIFF
--- a/cmd/aegisflow/main.go
+++ b/cmd/aegisflow/main.go
@@ -202,7 +202,12 @@ func main() {
 		recordSpendFn = budgetMgr.RecordSpend
 		budgetCheckFn = budgetMgr.CheckFunc()
 	}
+
+	// Request log for live feed
+	reqLog := admin.NewRequestLog(200)
+
 	handler := gateway.NewHandler(registry, rt, pe, ut, responseCache, wh, pgStore, analyticsCollector, cfg.Server.MaxBodySize, recordSpendFn, budgetCheckFn)
+	handler.SetRequestLogger(reqLog, cfg.Federation.ControlPlane.Name)
 
 	// Eval hooks
 	if cfg.Eval.Enabled {
@@ -263,9 +268,6 @@ func main() {
 	r.Get("/health", healthHandler)
 	r.Post("/v1/chat/completions", handler.ChatCompletion)
 	r.Get("/v1/models", handler.ListModels)
-
-	// Request log for live feed
-	reqLog := admin.NewRequestLog(200)
 
 	// Rollout manager
 	var rolloutAdapter admin.RolloutManager
@@ -329,10 +331,10 @@ func main() {
 			federationProvider = cp
 			log.Printf("federation control plane enabled (%d data planes)", len(cfg.Federation.DataPlanes))
 		} else if cfg.Federation.Mode == "data-plane" {
-			dp := federation.NewDataPlane(cfg.Federation.ControlPlane.URL, cfg.Federation.ControlPlane.Token, cfg.Federation.ControlPlane.SyncInterval)
+			dp := federation.NewDataPlane(cfg.Federation.ControlPlane.Name, cfg.Federation.ControlPlane.URL, cfg.Federation.ControlPlane.Token, cfg.Federation.ControlPlane.SyncInterval)
 			dp.Start()
 			defer dp.Stop()
-			log.Printf("federation data plane enabled (control: %s)", cfg.Federation.ControlPlane.URL)
+			log.Printf("federation data plane enabled (name: %s, control: %s)", cfg.Federation.ControlPlane.Name, cfg.Federation.ControlPlane.URL)
 		}
 	}
 

--- a/internal/admin/dashboard.html
+++ b/internal/admin/dashboard.html
@@ -659,6 +659,7 @@
             <th>Tenant</th>
             <th>Model</th>
             <th>Region</th>
+            <th>Data Plane</th>
             <th>Status</th>
             <th>Latency</th>
             <th>Tokens</th>
@@ -668,7 +669,7 @@
           </tr>
         </thead>
         <tbody id="feedTable">
-          <tr><td colspan="11" class="empty-state"><p>No requests yet</p><div class="hint">Send a request to see live feed data</div></td></tr>
+          <tr><td colspan="12" class="empty-state"><p>No requests yet</p><div class="hint">Send a request to see live feed data</div></td></tr>
         </tbody>
       </table>
     </div>
@@ -1391,7 +1392,7 @@ async function fetchRequests() {
 
     const tbody = document.getElementById('feedTable');
     if (total === 0) {
-      tbody.innerHTML = '<tr><td colspan="11" class="empty-state"><p>No requests yet</p></td></tr>';
+      tbody.innerHTML = '<tr><td colspan="12" class="empty-state"><p>No requests yet</p></td></tr>';
     } else {
       tbody.innerHTML = entries.map(r => {
         const time = new Date(r.timestamp).toLocaleTimeString();
@@ -1405,6 +1406,7 @@ async function fetchRequests() {
           <td><span class="badge badge-tenant">${r.tenant_id || '-'}</span></td>
           <td><span class="badge ${getModelBadgeClass(r.model || '')}">${r.model || '-'}</span></td>
           <td><span style="font-size:12px;color:var(--text-secondary);">${r.region || '-'}</span></td>
+          <td><span style="font-size:12px;color:var(--text-secondary);">${r.data_plane || '-'}</span></td>
           <td><span style="color:${statusColor};font-weight:600;">${r.status}</span></td>
           <td><span style="color:${latencyColor};font-weight:500;">${r.latency_ms}ms</span></td>
           <td style="font-weight:500;">${formatNumber(r.tokens || 0)}</td>

--- a/internal/admin/requestlog.go
+++ b/internal/admin/requestlog.go
@@ -9,18 +9,19 @@ import (
 
 // RequestEntry represents a single request in the live feed.
 type RequestEntry struct {
-	Timestamp  time.Time `json:"timestamp"`
-	RequestID  string    `json:"request_id"`
-	TenantID   string    `json:"tenant_id"`
-	Model      string    `json:"model"`
-	Provider   string    `json:"provider,omitempty"`
-	Region     string    `json:"region,omitempty"`
-	Status     int       `json:"status"`
-	LatencyMs  int64     `json:"latency_ms"`
-	Tokens     int       `json:"tokens"`
-	Cached     bool      `json:"cached"`
-	PolicyHit  string    `json:"policy_hit,omitempty"`
-	QualityScore int     `json:"quality_score"`
+	Timestamp    time.Time `json:"timestamp"`
+	RequestID    string    `json:"request_id"`
+	TenantID     string    `json:"tenant_id"`
+	Model        string    `json:"model"`
+	Provider     string    `json:"provider,omitempty"`
+	Region       string    `json:"region,omitempty"`
+	DataPlane    string    `json:"data_plane,omitempty"`
+	Status       int       `json:"status"`
+	LatencyMs    int64     `json:"latency_ms"`
+	Tokens       int       `json:"tokens"`
+	Cached       bool      `json:"cached"`
+	PolicyHit    string    `json:"policy_hit,omitempty"`
+	QualityScore int       `json:"quality_score"`
 }
 
 // RequestLog is a thread-safe ring buffer that stores recent requests for the live feed.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,22 +11,22 @@ import (
 )
 
 type Config struct {
-	Server    ServerConfig     `yaml:"server"`
-	Providers []ProviderConfig `yaml:"providers"`
-	Routes    []RouteConfig    `yaml:"routes"`
-	Tenants   []TenantConfig   `yaml:"tenants"`
-	RateLimit RateLimitConfig  `yaml:"rate_limit"`
-	Policies  PoliciesConfig   `yaml:"policies"`
-	Telemetry TelemetryConfig  `yaml:"telemetry"`
-	Logging   LoggingConfig    `yaml:"logging"`
-	Cache     CacheConfig      `yaml:"cache"`
-	Webhook   WebhookConfig    `yaml:"webhook"`
-	Database  DatabaseConfig   `yaml:"database"`
-	Admin     AdminConfig      `yaml:"admin"`
-	Aliases   AliasConfig      `yaml:"aliases"`
-	Transform TransformConfig  `yaml:"transform"`
-	Analytics AnalyticsConfig  `yaml:"analytics"`
-	Budgets   BudgetsConfig    `yaml:"budgets"`
+	Server     ServerConfig     `yaml:"server"`
+	Providers  []ProviderConfig `yaml:"providers"`
+	Routes     []RouteConfig    `yaml:"routes"`
+	Tenants    []TenantConfig   `yaml:"tenants"`
+	RateLimit  RateLimitConfig  `yaml:"rate_limit"`
+	Policies   PoliciesConfig   `yaml:"policies"`
+	Telemetry  TelemetryConfig  `yaml:"telemetry"`
+	Logging    LoggingConfig    `yaml:"logging"`
+	Cache      CacheConfig      `yaml:"cache"`
+	Webhook    WebhookConfig    `yaml:"webhook"`
+	Database   DatabaseConfig   `yaml:"database"`
+	Admin      AdminConfig      `yaml:"admin"`
+	Aliases    AliasConfig      `yaml:"aliases"`
+	Transform  TransformConfig  `yaml:"transform"`
+	Analytics  AnalyticsConfig  `yaml:"analytics"`
+	Budgets    BudgetsConfig    `yaml:"budgets"`
 	Eval       EvalConfig       `yaml:"eval"`
 	Federation FederationConfig `yaml:"federation"`
 }
@@ -45,6 +45,7 @@ type DataPlaneConfig struct {
 }
 
 type ControlPlaneRef struct {
+	Name         string        `yaml:"name"`
 	URL          string        `yaml:"url"`
 	Token        string        `yaml:"token"`
 	SyncInterval time.Duration `yaml:"sync_interval"`

--- a/internal/federation/dataplane.go
+++ b/internal/federation/dataplane.go
@@ -12,6 +12,7 @@ import (
 
 // DataPlane polls a control plane for config and pushes status/metrics.
 type DataPlane struct {
+	name         string
 	controlURL   string
 	token        string
 	syncInterval time.Duration
@@ -20,8 +21,9 @@ type DataPlane struct {
 }
 
 // NewDataPlane creates a data plane that syncs with the given control plane URL.
-func NewDataPlane(controlURL, token string, syncInterval time.Duration) *DataPlane {
+func NewDataPlane(name, controlURL, token string, syncInterval time.Duration) *DataPlane {
 	return &DataPlane{
+		name:         name,
 		controlURL:   controlURL,
 		token:        token,
 		syncInterval: syncInterval,
@@ -33,7 +35,7 @@ func NewDataPlane(controlURL, token string, syncInterval time.Duration) *DataPla
 // Start begins the background sync loop.
 func (dp *DataPlane) Start() {
 	go dp.syncLoop()
-	log.Printf("federation data plane started (control: %s, interval: %s)", dp.controlURL, dp.syncInterval)
+	log.Printf("federation data plane started (name: %s, control: %s, interval: %s)", dp.name, dp.controlURL, dp.syncInterval)
 }
 
 // Stop terminates the background sync loop.
@@ -74,6 +76,7 @@ func (dp *DataPlane) pullConfig() {
 
 func (dp *DataPlane) pushStatus() {
 	status := PlaneStatus{
+		Name:     dp.name,
 		Healthy:  true,
 		LastSeen: time.Now(),
 	}

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -10,6 +10,9 @@ import (
 	"context"
 	"time"
 
+	chimw "github.com/go-chi/chi/v5/middleware"
+
+	"github.com/saivedant169/AegisFlow/internal/admin"
 	"github.com/saivedant169/AegisFlow/internal/analytics"
 	"github.com/saivedant169/AegisFlow/internal/cache"
 	"github.com/saivedant169/AegisFlow/internal/eval"
@@ -24,15 +27,15 @@ import (
 )
 
 type Handler struct {
-	registry    *provider.Registry
-	router      *router.Router
-	policy      *policy.Engine
-	usage       *usage.Tracker
-	cache       cache.Cache
-	webhook     *webhook.Notifier
-	store       *storage.PostgresStore
-	dbQueue     chan storage.UsageEvent
-	analytics   *analytics.Collector
+	registry       *provider.Registry
+	router         *router.Router
+	policy         *policy.Engine
+	usage          *usage.Tracker
+	cache          cache.Cache
+	webhook        *webhook.Notifier
+	store          *storage.PostgresStore
+	dbQueue        chan storage.UsageEvent
+	analytics      *analytics.Collector
 	maxBodySize    int64
 	recordSpend    func(tenantID, model string, cost float64)
 	budgetCheck    func(tenantID, model string) (bool, []string, string)
@@ -41,11 +44,19 @@ type Handler struct {
 	evalLatencyMul float64
 	evalWebhook    *eval.WebhookEvaluator
 	auditLog       func(actor, actorRole, action, resource, detail, tenantID, model string)
+	requestLog     *admin.RequestLog
+	dataPlaneName  string
 }
 
 // SetAuditLogger sets the audit logging function on the handler.
 func (h *Handler) SetAuditLogger(logFn func(actor, actorRole, action, resource, detail, tenantID, model string)) {
 	h.auditLog = logFn
+}
+
+// SetRequestLogger configures live request feed logging on the handler.
+func (h *Handler) SetRequestLogger(reqLog *admin.RequestLog, dataPlaneName string) {
+	h.requestLog = reqLog
+	h.dataPlaneName = dataPlaneName
 }
 
 const (
@@ -159,6 +170,7 @@ func (h *Handler) ChatCompletion(w http.ResponseWriter, r *http.Request) {
 			log.Printf("cache hit: %s", cacheKey[:20])
 			w.Header().Set("Content-Type", "application/json")
 			w.Header().Set("X-AegisFlow-Cache", "HIT")
+			h.logRequest(startTime, r, tenantID, req.Model, "cache", http.StatusOK, cached.Usage.TotalTokens, true, "")
 			json.NewEncoder(w).Encode(cached)
 			return
 		}
@@ -167,6 +179,7 @@ func (h *Handler) ChatCompletion(w http.ResponseWriter, r *http.Request) {
 	routed, err := h.router.RouteWithProvider(r.Context(), &req)
 	if err != nil {
 		h.recordAnalytics(tenantID, req.Model, "", http.StatusBadGateway, startTime, 0)
+		h.logRequest(startTime, r, tenantID, req.Model, "", http.StatusBadGateway, 0, false, "")
 		writeError(w, http.StatusBadGateway, "provider_error", err.Error())
 		return
 	}
@@ -179,6 +192,7 @@ func (h *Handler) ChatCompletion(w http.ResponseWriter, r *http.Request) {
 			if v.Action == policy.ActionBlock {
 				h.fireWebhook("policy_violation", v.PolicyName, string(v.Action), tenantID, req.Model, v.Message)
 				h.recordAnalytics(tenantID, req.Model, providerName, http.StatusForbidden, startTime, 0)
+				h.logRequest(startTime, r, tenantID, req.Model, providerName, http.StatusForbidden, resp.Usage.TotalTokens, false, routed.Region)
 				if h.auditLog != nil {
 					h.auditLog("system", "system", "policy.block", "policy:"+v.PolicyName, `{"message":"`+v.Message+`","phase":"output"}`, tenantID, req.Model)
 				}
@@ -245,6 +259,7 @@ func (h *Handler) ChatCompletion(w http.ResponseWriter, r *http.Request) {
 
 	// Record analytics data point
 	h.recordAnalytics(tenantID, req.Model, providerName, 200, startTime, int64(resp.Usage.TotalTokens), qualityScore)
+	h.logRequest(startTime, r, tenantID, req.Model, providerName, http.StatusOK, resp.Usage.TotalTokens, false, routed.Region)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("X-AegisFlow-Cache", "MISS")
@@ -368,6 +383,26 @@ func extractContent(messages []types.Message) string {
 		parts = append(parts, m.Content)
 	}
 	return strings.Join(parts, " ")
+}
+
+func (h *Handler) logRequest(startTime time.Time, r *http.Request, tenantID, model, providerName string, status int, tokens int, cached bool, region string) {
+	if h.requestLog == nil {
+		return
+	}
+	h.requestLog.Add(admin.RequestEntry{
+		Timestamp:    time.Now(),
+		RequestID:    chimw.GetReqID(r.Context()),
+		TenantID:     tenantID,
+		Model:        model,
+		Provider:     providerName,
+		Region:       region,
+		DataPlane:    h.dataPlaneName,
+		Status:       status,
+		LatencyMs:    time.Since(startTime).Milliseconds(),
+		Tokens:       tokens,
+		Cached:       cached,
+		QualityScore: 0,
+	})
 }
 
 func writeError(w http.ResponseWriter, code int, errType, message string) {

--- a/internal/gateway/handler_test.go
+++ b/internal/gateway/handler_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/saivedant169/AegisFlow/internal/admin"
 	"github.com/saivedant169/AegisFlow/internal/analytics"
 	"github.com/saivedant169/AegisFlow/internal/cache"
 	"github.com/saivedant169/AegisFlow/internal/config"
@@ -300,6 +301,91 @@ func TestChatCompletionRecordsAnalytics(t *testing.T) {
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
 	// If we got here without panic, analytics recording path was exercised
+}
+
+func TestChatCompletionLogsRequestFeedEntry(t *testing.T) {
+	registry := provider.NewRegistry()
+	registry.Register(provider.NewMockProvider("mock", 0))
+	routes := []config.RouteConfig{
+		{Match: config.RouteMatch{Model: "*"}, Providers: []string{"mock"}, Strategy: "priority"},
+	}
+	rt := router.NewRouter(routes, registry)
+	pe := policy.NewEngine(nil, nil)
+	ut := usage.NewTracker(usage.NewStore())
+	reqLog := admin.NewRequestLog(10)
+	h := NewHandler(registry, rt, pe, ut, nil, nil, nil, nil, 0, nil, nil)
+	h.SetRequestLogger(reqLog, "plane-a")
+
+	reqBody := types.ChatCompletionRequest{
+		Model:    "mock",
+		Messages: []types.Message{{Role: "user", Content: "request log test"}},
+	}
+	body, _ := json.Marshal(reqBody)
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.ChatCompletion(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	entries := reqLog.Recent(1)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 request log entry, got %d", len(entries))
+	}
+	if entries[0].Provider != "mock" {
+		t.Fatalf("expected provider mock, got %q", entries[0].Provider)
+	}
+	if entries[0].DataPlane != "plane-a" {
+		t.Fatalf("expected data plane plane-a, got %q", entries[0].DataPlane)
+	}
+	if entries[0].Status != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", entries[0].Status)
+	}
+}
+
+func TestChatCompletionLogsCacheHits(t *testing.T) {
+	registry := provider.NewRegistry()
+	registry.Register(provider.NewMockProvider("mock", 0))
+	routes := []config.RouteConfig{
+		{Match: config.RouteMatch{Model: "*"}, Providers: []string{"mock"}, Strategy: "priority"},
+	}
+	rt := router.NewRouter(routes, registry)
+	pe := policy.NewEngine(nil, nil)
+	ut := usage.NewTracker(usage.NewStore())
+	c := cache.NewMemoryCache(5*time.Minute, 100)
+	reqLog := admin.NewRequestLog(10)
+	h := NewHandler(registry, rt, pe, ut, c, nil, nil, nil, 0, nil, nil)
+	h.SetRequestLogger(reqLog, "plane-a")
+
+	reqBody := types.ChatCompletionRequest{
+		Model:    "mock",
+		Messages: []types.Message{{Role: "user", Content: "cache log test"}},
+	}
+	body, _ := json.Marshal(reqBody)
+
+	req1 := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	req1.Header.Set("Content-Type", "application/json")
+	w1 := httptest.NewRecorder()
+	h.ChatCompletion(w1, req1)
+
+	req2 := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	req2.Header.Set("Content-Type", "application/json")
+	w2 := httptest.NewRecorder()
+	h.ChatCompletion(w2, req2)
+
+	entries := reqLog.Recent(2)
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 request log entries, got %d", len(entries))
+	}
+	if !entries[0].Cached {
+		t.Fatalf("expected newest entry to be cache hit")
+	}
+	if entries[0].Provider != "cache" {
+		t.Fatalf("expected cache provider marker, got %q", entries[0].Provider)
+	}
 }
 
 func TestListModelsReturnsModels(t *testing.T) {


### PR DESCRIPTION
Summary
- add a `data_plane` field to live request log entries and render it in the dashboard feed
- wire the gateway to emit request-log entries for cache hits, upstream responses, and provider errors
- carry the configured control-plane name into data-plane status pushes and gateway request logging

Why
- the federation dashboard cannot show per-plane request distribution until the live feed is tagged with the plane that handled each request

Validation
- `go test ./internal/gateway`
- `go test ./internal/federation`
- `go test ./internal/admin`
- `go test ./cmd/aegisflow`

Closes #45