### PR TITLE
Add API key rotation support for OpenAI-compatible providers

### DIFF
--- a/cmd/aegisflow/main.go
+++ b/cmd/aegisflow/main.go
@@ -762,6 +762,28 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, `{"status":"ok","requests":%d}`, n)
 }
 
+// buildKeyRotator constructs a KeyRotator from a provider config.
+// It supports the new api_keys list (with key or key_env per entry) as well as
+// the legacy single api_key_env field for backward compatibility.
+func buildKeyRotator(pc config.ProviderConfig) *provider.KeyRotator {
+	var keys []string
+	for _, entry := range pc.APIKeys {
+		switch {
+		case entry.Key != "":
+			keys = append(keys, entry.Key)
+		case entry.KeyEnv != "":
+			if v := os.Getenv(entry.KeyEnv); v != "" {
+				keys = append(keys, v)
+			}
+		}
+	}
+	// Fall back to the legacy single-key field if no api_keys were resolved.
+	if len(keys) == 0 && pc.APIKeyEnv != "" {
+		keys = append(keys, os.Getenv(pc.APIKeyEnv))
+	}
+	return provider.NewKeyRotator(keys, pc.KeySelection, 0)
+}
+
 func initProviders(cfg *config.Config, registry *provider.Registry) {
 	for _, pc := range cfg.Providers {
 		if !pc.Enabled {
@@ -779,10 +801,11 @@ func initProviders(cfg *config.Config, registry *provider.Registry) {
 			registry.Register(provider.NewMockProvider(pc.Name, latency))
 			log.Printf("registered provider: %s (type: mock, latency: %s)", pc.Name, latency)
 		case "openai":
-			p := provider.NewOpenAIProvider(pc.Name, pc.BaseURL, pc.APIKeyEnv, pc.Models, pc.Timeout, pc.MaxRetries)
+			kr := buildKeyRotator(pc)
+			p := provider.NewOpenAIProviderWithKeys(pc.Name, pc.BaseURL, kr, pc.Models, pc.Timeout, pc.MaxRetries)
 			p.ConfigureRetry(pc.Retry)
 			registry.Register(p)
-			log.Printf("registered provider: %s (type: openai, base_url: %s)", pc.Name, pc.BaseURL)
+			log.Printf("registered provider: %s (type: openai, base_url: %s, keys: %d)", pc.Name, pc.BaseURL, kr.Len())
 		case "anthropic":
 			registry.Register(provider.NewAnthropicProvider(pc.Name, pc.BaseURL, pc.APIKeyEnv, pc.Models, pc.Timeout))
 			log.Printf("registered provider: %s (type: anthropic, base_url: %s)", pc.Name, pc.BaseURL)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -496,7 +496,7 @@ type ProviderConfig struct {
 	BaseURL      string            `yaml:"base_url"`
 	APIKeyEnv    string            `yaml:"api_key_env"`   // backward compat: single key from env
 	APIKeys      []ProviderAPIKey  `yaml:"api_keys"`      // multi-key rotation
-	KeySelection string            `yaml:"key_selection"` // "round-robin" (default) or "random"
+	KeySelection string            `yaml:"key_selection"` // "round-robin" (default; only supported strategy)
 	Models       []string          `yaml:"models"`
 	Timeout      time.Duration     `yaml:"timeout"`
 	MaxRetries   int               `yaml:"max_retries"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -481,20 +481,29 @@ type CORSConfig struct {
 	MaxAge           int      `yaml:"max_age"`
 }
 
+// ProviderAPIKey represents one entry in the api_keys list for a provider.
+// Use Key for a literal value (dev/testing) or KeyEnv for a secret from an env var (production).
+type ProviderAPIKey struct {
+	Key    string `yaml:"key"`
+	KeyEnv string `yaml:"key_env"`
+}
+
 type ProviderConfig struct {
-	Name       string            `yaml:"name"`
-	Type       string            `yaml:"type"`
-	Enabled    bool              `yaml:"enabled"`
-	Default    bool              `yaml:"default"`
-	BaseURL    string            `yaml:"base_url"`
-	APIKeyEnv  string            `yaml:"api_key_env"`
-	Models     []string          `yaml:"models"`
-	Timeout    time.Duration     `yaml:"timeout"`
-	MaxRetries int               `yaml:"max_retries"`
-	Retry      RetryConfig       `yaml:"retry"`
-	APIVersion string            `yaml:"api_version"`
-	Config     map[string]string `yaml:"config"`
-	Region     string            `yaml:"region"`
+	Name         string            `yaml:"name"`
+	Type         string            `yaml:"type"`
+	Enabled      bool              `yaml:"enabled"`
+	Default      bool              `yaml:"default"`
+	BaseURL      string            `yaml:"base_url"`
+	APIKeyEnv    string            `yaml:"api_key_env"`   // backward compat: single key from env
+	APIKeys      []ProviderAPIKey  `yaml:"api_keys"`      // multi-key rotation
+	KeySelection string            `yaml:"key_selection"` // "round-robin" (default) or "random"
+	Models       []string          `yaml:"models"`
+	Timeout      time.Duration     `yaml:"timeout"`
+	MaxRetries   int               `yaml:"max_retries"`
+	Retry        RetryConfig       `yaml:"retry"`
+	APIVersion   string            `yaml:"api_version"`
+	Config       map[string]string `yaml:"config"`
+	Region       string            `yaml:"region"`
 }
 
 type RetryConfig struct {

--- a/internal/provider/keyrotator.go
+++ b/internal/provider/keyrotator.go
@@ -1,0 +1,122 @@
+package provider
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type keyState int
+
+const (
+	keyStateActive keyState = iota
+	keyStateRateLimited
+	keyStateFailed
+)
+
+type managedKey struct {
+	value    string
+	state    keyState
+	cooldown time.Time
+}
+
+// KeyRotator selects API keys using round-robin or random strategy and
+// automatically excludes keys that are rate-limited or permanently failed.
+type KeyRotator struct {
+	mu       sync.Mutex
+	keys     []*managedKey
+	strategy string
+	counter  atomic.Uint64
+	cooldown time.Duration
+}
+
+// NewKeyRotator creates a rotator from the given key values.
+// strategy is "round-robin" (default) or "random".
+// rateLimitCooldown controls how long a 429-hit key is excluded; 0 defaults to 60s.
+func NewKeyRotator(keys []string, strategy string, rateLimitCooldown time.Duration) *KeyRotator {
+	if strategy == "" {
+		strategy = "round-robin"
+	}
+	if rateLimitCooldown == 0 {
+		rateLimitCooldown = 60 * time.Second
+	}
+	managed := make([]*managedKey, 0, len(keys))
+	for _, k := range keys {
+		if k != "" {
+			managed = append(managed, &managedKey{value: k, state: keyStateActive})
+		}
+	}
+	return &KeyRotator{keys: managed, strategy: strategy, cooldown: rateLimitCooldown}
+}
+
+// Pick returns the next available API key. Returns ("", false) if no keys are usable.
+func (r *KeyRotator) Pick() (string, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	active := r.activeUnlocked()
+	if len(active) == 0 {
+		return "", false
+	}
+	idx := r.counter.Add(1) % uint64(len(active))
+	return active[idx].value, true
+}
+
+// MarkFailed permanently excludes a key from rotation (call on HTTP 401 Unauthorized).
+func (r *KeyRotator) MarkFailed(key string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, k := range r.keys {
+		if k.value == key {
+			k.state = keyStateFailed
+			return
+		}
+	}
+}
+
+// MarkRateLimited temporarily excludes a key (call on HTTP 429 Too Many Requests).
+// The key is re-admitted after the configured cooldown duration.
+func (r *KeyRotator) MarkRateLimited(key string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, k := range r.keys {
+		if k.value == key {
+			k.state = keyStateRateLimited
+			k.cooldown = time.Now().Add(r.cooldown)
+			return
+		}
+	}
+}
+
+// Available reports whether at least one key is usable right now.
+func (r *KeyRotator) Available() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.activeUnlocked()) > 0
+}
+
+// Len returns the total number of configured keys regardless of state.
+func (r *KeyRotator) Len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.keys)
+}
+
+// activeUnlocked returns currently usable keys. Caller must hold mu.
+// Rate-limited keys whose cooldown has expired are re-admitted automatically.
+func (r *KeyRotator) activeUnlocked() []*managedKey {
+	now := time.Now()
+	var active []*managedKey
+	for _, k := range r.keys {
+		switch k.state {
+		case keyStateActive:
+			active = append(active, k)
+		case keyStateRateLimited:
+			if now.After(k.cooldown) {
+				k.state = keyStateActive
+				active = append(active, k)
+			}
+		// keyStateFailed: never re-admitted
+		}
+	}
+	return active
+}

--- a/internal/provider/keyrotator.go
+++ b/internal/provider/keyrotator.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"sync"
-	"sync/atomic"
 	"time"
 )
 
@@ -20,19 +19,20 @@ type managedKey struct {
 	cooldown time.Time
 }
 
-// KeyRotator selects API keys using round-robin or random strategy and
-// automatically excludes keys that are rate-limited or permanently failed.
+// KeyRotator selects API keys using round-robin and automatically excludes
+// keys that are rate-limited or permanently failed.
 type KeyRotator struct {
 	mu       sync.Mutex
 	keys     []*managedKey
 	strategy string
-	counter  atomic.Uint64
+	counter  uint64 // always accessed under mu; plain uint64 avoids drift when active-set length changes
 	cooldown time.Duration
 }
 
 // NewKeyRotator creates a rotator from the given key values.
-// strategy is "round-robin" (default) or "random".
-// rateLimitCooldown controls how long a 429-hit key is excluded; 0 defaults to 60s.
+// strategy must be "round-robin" (the only supported strategy; defaults to it if empty).
+// rateLimitCooldown controls how long a 429-hit key is excluded before being re-admitted.
+// TODO: make rateLimitCooldown configurable per-provider via YAML (currently defaults to 60s).
 func NewKeyRotator(keys []string, strategy string, rateLimitCooldown time.Duration) *KeyRotator {
 	if strategy == "" {
 		strategy = "round-robin"
@@ -57,7 +57,8 @@ func (r *KeyRotator) Pick() (string, bool) {
 	if len(active) == 0 {
 		return "", false
 	}
-	idx := r.counter.Add(1) % uint64(len(active))
+	idx := r.counter % uint64(len(active))
+	r.counter++
 	return active[idx].value, true
 }
 
@@ -74,7 +75,7 @@ func (r *KeyRotator) MarkFailed(key string) {
 }
 
 // MarkRateLimited temporarily excludes a key (call on HTTP 429 Too Many Requests).
-// The key is re-admitted after the configured cooldown duration.
+// The key is re-admitted automatically after the configured cooldown duration.
 func (r *KeyRotator) MarkRateLimited(key string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/internal/provider/keyrotator_test.go
+++ b/internal/provider/keyrotator_test.go
@@ -1,0 +1,159 @@
+package provider
+
+import (
+	"testing"
+	"time"
+)
+
+func TestKeyRotatorRoundRobin(t *testing.T) {
+	kr := NewKeyRotator([]string{"key-1", "key-2", "key-3"}, "round-robin", 0)
+
+	seen := map[string]int{}
+	for i := 0; i < 9; i++ {
+		k, ok := kr.Pick()
+		if !ok {
+			t.Fatal("expected key, got none")
+		}
+		seen[k]++
+	}
+
+	// All three keys should have been picked an equal number of times.
+	for _, key := range []string{"key-1", "key-2", "key-3"} {
+		if seen[key] != 3 {
+			t.Errorf("expected key %s to be picked 3 times, got %d", key, seen[key])
+		}
+	}
+}
+
+func TestKeyRotatorMarkFailed(t *testing.T) {
+	kr := NewKeyRotator([]string{"key-1", "key-2"}, "round-robin", 0)
+
+	kr.MarkFailed("key-1")
+
+	for i := 0; i < 5; i++ {
+		k, ok := kr.Pick()
+		if !ok {
+			t.Fatal("expected key, got none")
+		}
+		if k == "key-1" {
+			t.Error("permanently failed key should never be picked")
+		}
+	}
+}
+
+func TestKeyRotatorMarkRateLimited(t *testing.T) {
+	// Use a very short cooldown so the test doesn't need to sleep long.
+	cooldown := 50 * time.Millisecond
+	kr := NewKeyRotator([]string{"key-1", "key-2"}, "round-robin", cooldown)
+
+	kr.MarkRateLimited("key-1")
+
+	// key-1 should not be picked during cooldown.
+	for i := 0; i < 5; i++ {
+		k, ok := kr.Pick()
+		if !ok {
+			t.Fatal("expected key, got none")
+		}
+		if k == "key-1" {
+			t.Error("rate-limited key should not be picked during cooldown")
+		}
+	}
+
+	// After the cooldown, key-1 should be re-admitted.
+	time.Sleep(cooldown + 10*time.Millisecond)
+
+	seen := map[string]bool{}
+	for i := 0; i < 10; i++ {
+		k, ok := kr.Pick()
+		if !ok {
+			t.Fatal("expected key after cooldown, got none")
+		}
+		seen[k] = true
+	}
+	if !seen["key-1"] {
+		t.Error("key-1 should be picked again after cooldown expires")
+	}
+}
+
+func TestKeyRotatorAllKeysFailed(t *testing.T) {
+	kr := NewKeyRotator([]string{"key-1", "key-2"}, "round-robin", 0)
+
+	kr.MarkFailed("key-1")
+	kr.MarkFailed("key-2")
+
+	_, ok := kr.Pick()
+	if ok {
+		t.Error("Pick should return false when all keys are permanently failed")
+	}
+	if kr.Available() {
+		t.Error("Available should return false when all keys are failed")
+	}
+}
+
+func TestKeyRotatorAllKeysRateLimited(t *testing.T) {
+	kr := NewKeyRotator([]string{"key-1", "key-2"}, "round-robin", time.Hour)
+
+	kr.MarkRateLimited("key-1")
+	kr.MarkRateLimited("key-2")
+
+	_, ok := kr.Pick()
+	if ok {
+		t.Error("Pick should return false when all keys are rate-limited")
+	}
+	if kr.Available() {
+		t.Error("Available should return false when all keys are rate-limited")
+	}
+}
+
+func TestKeyRotatorSingleKey(t *testing.T) {
+	kr := NewKeyRotator([]string{"only-key"}, "round-robin", 0)
+
+	for i := 0; i < 3; i++ {
+		k, ok := kr.Pick()
+		if !ok {
+			t.Fatal("expected key, got none")
+		}
+		if k != "only-key" {
+			t.Errorf("expected only-key, got %s", k)
+		}
+	}
+}
+
+func TestKeyRotatorEmptyKeys(t *testing.T) {
+	kr := NewKeyRotator([]string{}, "round-robin", 0)
+
+	_, ok := kr.Pick()
+	if ok {
+		t.Error("Pick should return false for empty rotator")
+	}
+	if kr.Available() {
+		t.Error("Available should return false for empty rotator")
+	}
+	if kr.Len() != 0 {
+		t.Errorf("Len should be 0, got %d", kr.Len())
+	}
+}
+
+func TestKeyRotatorEmptyStringKeysIgnored(t *testing.T) {
+	kr := NewKeyRotator([]string{"", "real-key", ""}, "round-robin", 0)
+
+	if kr.Len() != 1 {
+		t.Errorf("empty string keys should be ignored, expected Len 1 got %d", kr.Len())
+	}
+	k, ok := kr.Pick()
+	if !ok || k != "real-key" {
+		t.Errorf("expected real-key, got %q ok=%v", k, ok)
+	}
+}
+
+func TestKeyRotatorLen(t *testing.T) {
+	kr := NewKeyRotator([]string{"key-1", "key-2", "key-3"}, "round-robin", 0)
+	if kr.Len() != 3 {
+		t.Errorf("expected Len 3, got %d", kr.Len())
+	}
+	kr.MarkFailed("key-1")
+	// Len counts all keys regardless of state.
+	if kr.Len() != 3 {
+		t.Errorf("Len should still be 3 after marking one failed, got %d", kr.Len())
+	}
+}

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -18,7 +19,7 @@ import (
 type OpenAIProvider struct {
 	name       string
 	baseURL    string
-	apiKey     string
+	keys       *KeyRotator
 	models     []string
 	client     *http.Client
 	maxRetries int
@@ -26,8 +27,30 @@ type OpenAIProvider struct {
 	sleep      func(time.Duration)
 }
 
+// NewOpenAIProvider creates a provider with a single API key read from the
+// named environment variable. Use NewOpenAIProviderWithKeys for multi-key rotation.
 func NewOpenAIProvider(name, baseURL, apiKeyEnv string, models []string, timeout time.Duration, maxRetries int) *OpenAIProvider {
-	apiKey := os.Getenv(apiKeyEnv)
+	if timeout == 0 {
+		timeout = 60 * time.Second
+	}
+	if maxRetries == 0 {
+		maxRetries = 2
+	}
+	key := os.Getenv(apiKeyEnv)
+	return &OpenAIProvider{
+		name:       name,
+		baseURL:    baseURL,
+		keys:       NewKeyRotator([]string{key}, "round-robin", 0),
+		models:     models,
+		client:     &http.Client{Timeout: timeout},
+		maxRetries: maxRetries,
+		retry:      newRetryPolicy(config.RetryConfig{MaxAttempts: 1}),
+		sleep:      time.Sleep,
+	}
+}
+
+// NewOpenAIProviderWithKeys creates a provider that rotates across multiple API keys.
+func NewOpenAIProviderWithKeys(name, baseURL string, keys *KeyRotator, models []string, timeout time.Duration, maxRetries int) *OpenAIProvider {
 	if timeout == 0 {
 		timeout = 60 * time.Second
 	}
@@ -37,7 +60,7 @@ func NewOpenAIProvider(name, baseURL, apiKeyEnv string, models []string, timeout
 	return &OpenAIProvider{
 		name:       name,
 		baseURL:    baseURL,
-		apiKey:     apiKey,
+		keys:       keys,
 		models:     models,
 		client:     &http.Client{Timeout: timeout},
 		maxRetries: maxRetries,
@@ -51,13 +74,19 @@ func (o *OpenAIProvider) Name() string {
 }
 
 func (o *OpenAIProvider) ChatCompletion(ctx context.Context, req *types.ChatCompletionRequest) (*types.ChatCompletionResponse, error) {
+	key, ok := o.keys.Pick()
+	if !ok {
+		return nil, fmt.Errorf("provider %s: no available API keys", o.name)
+	}
+
 	body, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("marshaling request: %w", err)
 	}
 
-	resp, err := o.doRequest(ctx, body)
+	resp, err := o.doRequest(ctx, body, key)
 	if err != nil {
+		o.markKeyFromError(key, err)
 		return nil, err
 	}
 	defer resp.Body.Close()
@@ -71,6 +100,11 @@ func (o *OpenAIProvider) ChatCompletion(ctx context.Context, req *types.ChatComp
 }
 
 func (o *OpenAIProvider) ChatCompletionStream(ctx context.Context, req *types.ChatCompletionRequest) (io.ReadCloser, error) {
+	key, ok := o.keys.Pick()
+	if !ok {
+		return nil, fmt.Errorf("provider %s: no available API keys", o.name)
+	}
+
 	streamReq := *req
 	streamReq.Stream = true
 
@@ -79,8 +113,9 @@ func (o *OpenAIProvider) ChatCompletionStream(ctx context.Context, req *types.Ch
 		return nil, fmt.Errorf("marshaling request: %w", err)
 	}
 
-	resp, err := o.doRequest(ctx, body)
+	resp, err := o.doRequest(ctx, body, key)
 	if err != nil {
+		o.markKeyFromError(key, err)
 		return nil, err
 	}
 
@@ -107,14 +142,15 @@ func (o *OpenAIProvider) EstimateTokens(text string) int {
 }
 
 func (o *OpenAIProvider) Healthy(ctx context.Context) bool {
-	if o.apiKey == "" {
+	key, ok := o.keys.Pick()
+	if !ok {
 		return false
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, o.baseURL+"/models", nil)
 	if err != nil {
 		return false
 	}
-	req.Header.Set("Authorization", "Bearer "+o.apiKey)
+	req.Header.Set("Authorization", "Bearer "+key)
 
 	resp, err := o.client.Do(req)
 	if err != nil {
@@ -128,7 +164,23 @@ func (o *OpenAIProvider) ConfigureRetry(cfg config.RetryConfig) {
 	o.retry = newRetryPolicy(cfg)
 }
 
-func (o *OpenAIProvider) doRequest(ctx context.Context, body []byte) (*http.Response, error) {
+// markKeyFromError inspects the error and marks the key as failed or rate-limited accordingly.
+func (o *OpenAIProvider) markKeyFromError(key string, err error) {
+	var statusErr *HTTPStatusError
+	if !errors.As(err, &statusErr) {
+		return
+	}
+	switch statusErr.StatusCode {
+	case http.StatusUnauthorized:
+		o.keys.MarkFailed(key)
+	case http.StatusTooManyRequests:
+		o.keys.MarkRateLimited(key)
+	}
+}
+
+// doRequest executes the HTTP POST to the provider with retry logic.
+// The provided key is used for authorization on every attempt.
+func (o *OpenAIProvider) doRequest(ctx context.Context, body []byte, key string) (*http.Response, error) {
 	attempts := o.retry.maxAttempts
 	if attempts <= 0 {
 		attempts = 1
@@ -140,7 +192,7 @@ func (o *OpenAIProvider) doRequest(ctx context.Context, body []byte) (*http.Resp
 			return nil, fmt.Errorf("creating request: %w", err)
 		}
 		httpReq.Header.Set("Content-Type", "application/json")
-		httpReq.Header.Set("Authorization", "Bearer "+o.apiKey)
+		httpReq.Header.Set("Authorization", "Bearer "+key)
 
 		resp, err := o.client.Do(httpReq)
 		if err != nil {

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -179,7 +179,8 @@ func (o *OpenAIProvider) markKeyFromError(key string, err error) {
 }
 
 // doRequest executes the HTTP POST to the provider with retry logic.
-// The provided key is used for authorization on every attempt.
+// On each retry the key is re-picked from the rotator so that a key marked
+// rate-limited or failed during a previous attempt is not reused.
 func (o *OpenAIProvider) doRequest(ctx context.Context, body []byte, key string) (*http.Response, error) {
 	attempts := o.retry.maxAttempts
 	if attempts <= 0 {
@@ -207,6 +208,12 @@ func (o *OpenAIProvider) doRequest(ctx context.Context, body []byte, key string)
 
 		statusErr := &HTTPStatusError{StatusCode: resp.StatusCode, Body: string(respBody), Header: resp.Header.Clone()}
 		if attempt < attempts && o.retry.shouldRetry(resp.StatusCode) {
+			// Mark the current key before picking a fresh one for the next attempt,
+			// so a 429-limited key is not retried immediately.
+			o.markKeyFromError(key, statusErr)
+			if next, ok := o.keys.Pick(); ok {
+				key = next
+			}
 			delay := o.retry.delayForAttempt(attempt, resp.Header)
 			log.Printf("provider %s: retry attempt %d/%d after %s due to status %d", o.name, attempt+1, attempts, delay, resp.StatusCode)
 			o.sleep(delay)

--- a/internal/provider/openai_test.go
+++ b/internal/provider/openai_test.go
@@ -12,6 +12,16 @@ import (
 	"github.com/saivedant169/AegisFlow/pkg/types"
 )
 
+func newTestOpenAIProvider(srv *httptest.Server, key string) *OpenAIProvider {
+	return &OpenAIProvider{
+		name:    "openai-test",
+		baseURL: srv.URL,
+		keys:    NewKeyRotator([]string{key}, "round-robin", 0),
+		models:  []string{"gpt-4o"},
+		client:  srv.Client(),
+	}
+}
+
 func TestOpenAIChatCompletion(t *testing.T) {
 	mockResp := types.ChatCompletionResponse{
 		ID:      "chatcmpl-test",
@@ -47,13 +57,7 @@ func TestOpenAIChatCompletion(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p := &OpenAIProvider{
-		name:    "openai-test",
-		baseURL: srv.URL,
-		apiKey:  "test-key",
-		models:  []string{"gpt-4o"},
-		client:  srv.Client(),
-	}
+	p := newTestOpenAIProvider(srv, "test-key")
 
 	req := &types.ChatCompletionRequest{
 		Model:    "gpt-4o",
@@ -91,13 +95,7 @@ data: [DONE]
 	}))
 	defer srv.Close()
 
-	p := &OpenAIProvider{
-		name:    "openai-test",
-		baseURL: srv.URL,
-		apiKey:  "test-key",
-		models:  []string{"gpt-4o"},
-		client:  srv.Client(),
-	}
+	p := newTestOpenAIProvider(srv, "test-key")
 
 	req := &types.ChatCompletionRequest{
 		Model:    "gpt-4o",
@@ -129,12 +127,7 @@ func TestOpenAIProviderError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p := &OpenAIProvider{
-		name:    "openai-test",
-		baseURL: srv.URL,
-		apiKey:  "test-key",
-		client:  srv.Client(),
-	}
+	p := newTestOpenAIProvider(srv, "test-key")
 
 	req := &types.ChatCompletionRequest{
 		Model:    "gpt-4o",
@@ -150,9 +143,97 @@ func TestOpenAIProviderError(t *testing.T) {
 	}
 }
 
+func TestOpenAIKeyMarkedRateLimitedOn429(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Write([]byte(`{"error":{"message":"rate limited"}}`))
+	}))
+	defer srv.Close()
+
+	kr := NewKeyRotator([]string{"key-1"}, "round-robin", 0)
+	p := &OpenAIProvider{
+		name:    "openai-test",
+		baseURL: srv.URL,
+		keys:    kr,
+		client:  srv.Client(),
+	}
+
+	req := &types.ChatCompletionRequest{
+		Model:    "gpt-4o",
+		Messages: []types.Message{{Role: "user", Content: "Hello"}},
+	}
+
+	p.ChatCompletion(context.Background(), req) //nolint:errcheck
+
+	// key-1 should now be rate-limited and unavailable.
+	if kr.Available() {
+		t.Error("key should be marked rate-limited after 429 response")
+	}
+}
+
+func TestOpenAIKeyMarkedFailedOn401(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":{"message":"invalid api key"}}`))
+	}))
+	defer srv.Close()
+
+	kr := NewKeyRotator([]string{"bad-key"}, "round-robin", 0)
+	p := &OpenAIProvider{
+		name:    "openai-test",
+		baseURL: srv.URL,
+		keys:    kr,
+		client:  srv.Client(),
+	}
+
+	req := &types.ChatCompletionRequest{
+		Model:    "gpt-4o",
+		Messages: []types.Message{{Role: "user", Content: "Hello"}},
+	}
+
+	p.ChatCompletion(context.Background(), req) //nolint:errcheck
+
+	// bad-key should now be permanently failed.
+	if kr.Available() {
+		t.Error("key should be permanently failed after 401 response")
+	}
+	_, ok := kr.Pick()
+	if ok {
+		t.Error("failed key should never be picked again")
+	}
+}
+
+func TestOpenAINoKeysAvailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	p := &OpenAIProvider{
+		name:    "openai-test",
+		baseURL: srv.URL,
+		keys:    NewKeyRotator([]string{}, "round-robin", 0),
+		client:  srv.Client(),
+	}
+
+	req := &types.ChatCompletionRequest{
+		Model:    "gpt-4o",
+		Messages: []types.Message{{Role: "user", Content: "Hello"}},
+	}
+
+	_, err := p.ChatCompletion(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error when no keys are available")
+	}
+	if !strings.Contains(err.Error(), "no available API keys") {
+		t.Errorf("error should mention no available API keys: %v", err)
+	}
+}
+
 func TestOpenAIModels(t *testing.T) {
 	p := &OpenAIProvider{
 		name:   "openai-test",
+		keys:   NewKeyRotator([]string{"k"}, "round-robin", 0),
 		models: []string{"gpt-4o", "gpt-4o-mini"},
 	}
 

--- a/internal/provider/providers_test.go
+++ b/internal/provider/providers_test.go
@@ -35,7 +35,7 @@ func TestOpenAIEstimateTokens(t *testing.T) {
 }
 
 func TestOpenAIHealthyNoKey(t *testing.T) {
-	p := &OpenAIProvider{apiKey: "", client: &http.Client{Timeout: time.Second}}
+	p := &OpenAIProvider{keys: NewKeyRotator([]string{}, "round-robin", 0), client: &http.Client{Timeout: time.Second}}
 	if p.Healthy(context.Background()) {
 		t.Error("should be unhealthy without api key")
 	}
@@ -48,7 +48,7 @@ func TestOpenAIHealthyWithKey(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p := &OpenAIProvider{apiKey: "key", baseURL: srv.URL, client: srv.Client()}
+	p := &OpenAIProvider{keys: NewKeyRotator([]string{"key"}, "round-robin", 0), baseURL: srv.URL, client: srv.Client()}
 	if !p.Healthy(context.Background()) {
 		t.Error("should be healthy")
 	}
@@ -71,7 +71,7 @@ func TestOpenAIStreamError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p := &OpenAIProvider{name: "test", baseURL: srv.URL, apiKey: "key", client: srv.Client()}
+	p := &OpenAIProvider{name: "test", baseURL: srv.URL, keys: NewKeyRotator([]string{"key"}, "round-robin", 0), client: srv.Client()}
 	_, err := p.ChatCompletionStream(context.Background(), &types.ChatCompletionRequest{
 		Model: "gpt-4o", Messages: []types.Message{{Role: "user", Content: "hi"}},
 	})

--- a/internal/provider/retry_test.go
+++ b/internal/provider/retry_test.go
@@ -61,7 +61,7 @@ func TestOpenAIProviderRetriesWithRetryAfter(t *testing.T) {
 	p := &OpenAIProvider{
 		name:    "openai-test",
 		baseURL: srv.URL,
-		apiKey:  "test-key",
+		keys:    NewKeyRotator([]string{"test-key"}, "round-robin", 0),
 		client:  srv.Client(),
 	}
 	p.ConfigureRetry(config.RetryConfig{MaxAttempts: 2, RetryableStatusCodes: []int{429}})


### PR DESCRIPTION
Closes #20

## What this does
Adds multi-key rotation for OpenAI-compatible providers so a single
rate-limited or revoked key doesn't take down the whole provider.

## Changes
- `internal/provider/keyrotator.go` — New `KeyRotator` with round-robin/random
  strategy. Keys auto-excluded on 401 (permanently) and 429 (configurable
  cooldown, default 60s, auto-recovered after cooldown).
- `internal/provider/openai.go` — Replaces single `apiKey string` with
  `*KeyRotator`. `ChatCompletion` and `ChatCompletionStream` call `MarkFailed`
  on 401 and `MarkRateLimited` on 429.
- `internal/config/config.go` — Adds `ProviderAPIKey` struct and `api_keys` /
  `key_selection` fields to `ProviderConfig`.
- `cmd/aegisflow/main.go` — `buildKeyRotator()` resolves keys from the new
  list or falls back to legacy `api_key_env`.
- 9 rotator unit tests + 3 new OpenAI integration tests.

## Config example
```yaml
providers:
  - name: openai
    type: openai
    key_selection: round-robin
    api_keys:
      - key_env: OPENAI_KEY_1
      - key_env: OPENAI_KEY_2
