### PR TITLE
fix(mcpgw): include tool/upstream context in unreachable error

### DIFF
--- a/internal/mcpgw/server.go
+++ b/internal/mcpgw/server.go
@@ -234,6 +234,18 @@ func (g *Gateway) buildInitializeResponse(req *JSONRPCRequest) JSONRPCResponse {
 	return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: result}
 }
 
+// formatUpstreamError builds a user-friendly error message for when the
+// gateway cannot reach an upstream. It includes the tool name, the upstream
+// name from config, the original error, and a remediation hint pointing at
+// the configured URL. The URL is taken from config and is safe to expose;
+// no credentials are included.
+func formatUpstreamError(toolName string, upstream *UpstreamConfig, err error) string {
+	return fmt.Sprintf(
+		"upstream %q unreachable for tool %q: %s; check that the upstream is running at %s",
+		upstream.Name, toolName, err.Error(), upstream.URL,
+	)
+}
+
 // processToolCall evaluates a tools/call request and returns the response
 // (used by SSE path; the direct path still calls handleToolCall).
 func (g *Gateway) processToolCall(req *JSONRPCRequest) JSONRPCResponse {
@@ -272,7 +284,7 @@ func (g *Gateway) processToolCall(req *JSONRPCRequest) JSONRPCResponse {
 			}
 			resp, err := g.proxyToUpstream(upstream, req)
 			if err != nil {
-				return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Error: &JSONRPCError{Code: -32000, Message: "upstream error: " + err.Error()}}
+				return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Error: &JSONRPCError{Code: -32000, Message: formatUpstreamError(params.Name, upstream, err)}}
 			}
 			return *resp
 		}
@@ -289,7 +301,7 @@ func (g *Gateway) processToolCall(req *JSONRPCRequest) JSONRPCResponse {
 		}
 		resp, err := g.proxyToUpstream(upstream, req)
 		if err != nil {
-			return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Error: &JSONRPCError{Code: -32000, Message: "upstream error: " + err.Error()}}
+			return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Error: &JSONRPCError{Code: -32000, Message: formatUpstreamError(params.Name, upstream, err)}}
 		}
 		return *resp
 	default:
@@ -352,7 +364,7 @@ func (g *Gateway) handleToolCall(w http.ResponseWriter, req *JSONRPCRequest) {
 			}
 			resp, err := g.proxyToUpstream(upstream, req)
 			if err != nil {
-				g.writeError(w, req.ID, -32000, "upstream error: "+err.Error())
+				g.writeError(w, req.ID, -32000, formatUpstreamError(params.Name, upstream, err))
 				return
 			}
 			w.Header().Set("Content-Type", "application/json")
@@ -376,7 +388,7 @@ func (g *Gateway) handleToolCall(w http.ResponseWriter, req *JSONRPCRequest) {
 
 		resp, err := g.proxyToUpstream(upstream, req)
 		if err != nil {
-			g.writeError(w, req.ID, -32000, "upstream error: "+err.Error())
+			g.writeError(w, req.ID, -32000, formatUpstreamError(params.Name, upstream, err))
 			return
 		}
 

--- a/internal/mcpgw/server_test.go
+++ b/internal/mcpgw/server_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/saivedant169/AegisFlow/internal/toolpolicy"
@@ -266,6 +267,68 @@ func TestDefaultBlockPolicy(t *testing.T) {
 	}
 	if resp.Error.Code != -32001 {
 		t.Fatalf("expected -32001, got %d", resp.Error.Code)
+	}
+}
+
+// TestToolCallUpstreamUnreachableErrorMessage verifies that when the MCP
+// gateway cannot reach an upstream, the error message includes the tool name,
+// the upstream name from config, and a remediation hint pointing at the URL.
+// This is the fix for issue #82.
+func TestToolCallUpstreamUnreachableErrorMessage(t *testing.T) {
+	// Start a real upstream server, grab its URL, then shut it down so
+	// any subsequent request fails with a connection error.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	deadURL := upstream.URL
+	upstream.Close()
+
+	engine := toolpolicy.NewEngine([]toolpolicy.ToolRule{
+		{Protocol: "mcp", Tool: "github.list_repos", Decision: "allow"},
+	}, "block")
+
+	gw := NewGateway(engine, nil, nil, []UpstreamConfig{
+		{Name: "github-prod", URL: deadURL, Tools: []string{"github.*"}},
+	})
+
+	reqBody := JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "tools/call",
+		Params: json.RawMessage(`{
+			"name": "github.list_repos",
+			"arguments": {"org": "aegisflow"}
+		}`),
+	}
+	body, _ := json.Marshal(reqBody)
+
+	req := httptest.NewRequest("POST", "/mcp", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	gw.ServeHTTP(rec, req)
+
+	var resp JSONRPCResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Error == nil {
+		t.Fatal("expected error for unreachable upstream, got none")
+	}
+	if resp.Error.Code != -32000 {
+		t.Fatalf("expected upstream error code -32000, got %d", resp.Error.Code)
+	}
+
+	msg := resp.Error.Message
+	if !strings.Contains(msg, "github.list_repos") {
+		t.Errorf("error message should include tool name %q, got: %s", "github.list_repos", msg)
+	}
+	if !strings.Contains(msg, "github-prod") {
+		t.Errorf("error message should include upstream name %q, got: %s", "github-prod", msg)
+	}
+	if !strings.Contains(msg, deadURL) {
+		t.Errorf("error message should include upstream URL %q (remediation hint), got: %s", deadURL, msg)
+	}
+	if !strings.Contains(strings.ToLower(msg), "check that the upstream is running") {
+		t.Errorf("error message should include remediation hint 'check that the upstream is running', got: %s", msg)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fixes #82 — MCP gateway upstream errors now tell users which tool call failed, which upstream was chosen, and where to look.
- Adds a `formatUpstreamError` helper and applies it at all four call sites (SSE `processToolCall` + direct `handleToolCall`, each in the preapproved-review and allow branches).
- Adds a unit test in `internal/mcpgw/server_test.go` that stands up an `httptest` server, closes it to force `connection refused`, and asserts the resulting JSON-RPC error contains the tool name, upstream name, URL, and remediation hint.

## Before / after

Before:
```
upstream error: Post "http://localhost:3000": dial tcp 127.0.0.1:3000: connect: connection refused
```

After:
```
upstream "github-prod" unreachable for tool "github.list_repos": Post "http://localhost:3000": dial tcp 127.0.0.1:3000: connect: connection refused; check that the upstream is running at http://localhost:3000
```

No credentials are leaked — only `Name` and `URL` from config are used, and per the issue notes the URL is safe to expose.

## Test plan
- [x] `go test ./internal/mcpgw/... -run TestToolCallUpstreamUnreachableErrorMessage -v` — new test passes
- [x] `go test ./...` — full suite stays green
- [x] `go build ./...` — clean
- [ ] Manual repro from the issue: start AegisFlow with `configs/realworld.yaml` without the mock-mcp server, run `./bin/aegisctl test-action --protocol mcp --tool github.list_repos --target foo`, and confirm the new error shape