### PR TITLE
Harden deploy config and validation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,43 @@
+.git
+.github
+.DS_Store
+**/.DS_Store
+
+# Local configuration and run artifacts
+.env
+.env.*
+.aegisflow-run/
+.claude/
+.mcp.json
+
+# Build and test outputs
+bin/
+aegisflow
+aegisflow-operator
+aegisctl
+*.test
+*.out
+coverage.html
+
+# Local notes and media
+AegisFlow_Enterprise_Grade_Uplift_Plan_2026-04-06.md
+AegisFlow_Pivot_Plan_2026-04-06.md
+DEMO_GUIDE.txt
+DEVTO_ARTICLE.md
+INTERVIEW_NOTES.md
+LAUNCH_POSTS.txt
+ai_gateway_project_idea.md
+resume/
+*.gif
+*.mov
+*.mp4
+*.png
+
+# Generated and auxiliary docs
+docs/plans/
+docs/specs/
+docs/superpowers/
+Awesome-LLMOps
+
+# Example build artifacts
+examples/wasm-plugin/plugin.wasm

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,15 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Format
+        run: |
+          unformatted="$(gofmt -l $(find . -name '*.go' -not -path './vendor/*'))"
+          if [ -n "$unformatted" ]; then
+            echo "Go files need formatting:"
+            echo "$unformatted"
+            exit 1
+          fi
+
       - name: Build
         run: go build ./...
 

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ docs/specs/
 docs/plans/
 docs/superpowers/
 Awesome-LLMOps
+.claude/
 .claude/worktrees/
 
 # PR-writer installer artifacts

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ COPY configs/policy-packs/ /app/configs/policy-packs/
 COPY scripts/demo.sh /app/scripts/
 RUN chmod +x /app/scripts/*.sh
 EXPOSE 8080 8081 8082
-ENTRYPOINT ["./aegisflow", "--config", "configs/aegisflow.yaml"]
+ENTRYPOINT ["./aegisflow"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
-.PHONY: build run test lint fmt docker-build docker-up benchmark clean
+.PHONY: build run test lint fmt fmt-check docker-build docker-up benchmark clean
 
 BINARY=aegisflow
 CONFIG=configs/aegisflow.yaml
+GO_FILES=$(shell find . -name '*.go' -not -path './vendor/*')
 
 build:
 	go build -o bin/$(BINARY) ./cmd/aegisflow
@@ -17,7 +18,15 @@ lint:
 	golangci-lint run ./...
 
 fmt:
-	gofmt -s -w .
+	gofmt -s -w $(GO_FILES)
+
+fmt-check:
+	@files="$$(gofmt -l $(GO_FILES))"; \
+	if [ -n "$$files" ]; then \
+		echo "Go files need formatting:"; \
+		echo "$$files"; \
+		exit 1; \
+	fi
 
 docker-build:
 	docker build -t aegisflow:latest .

--- a/api/v1alpha1/webhook.go
+++ b/api/v1alpha1/webhook.go
@@ -240,4 +240,3 @@ func SetupWebhooksWithManager(scheme *runtime.Scheme, webhookServer WebhookRegis
 type WebhookRegistrar interface {
 	Register(path string, hook http.Handler)
 }
-

--- a/cmd/aegisctl/simulate.go
+++ b/cmd/aegisctl/simulate.go
@@ -60,10 +60,10 @@ func cmdSimulate(adminURL string, args []string) {
 }
 
 type simulateResponse struct {
-	Action   string                        `json:"action"`
-	Decision string                        `json:"decision"`
+	Action   string                          `json:"action"`
+	Decision string                          `json:"decision"`
 	Trace    *toolpolicy.PolicyDecisionTrace `json:"trace"`
-	Local    bool                          `json:"-"`
+	Local    bool                            `json:"-"`
 }
 
 func remoteSimulate(adminURL, protocol, tool, target, capability string) (*simulateResponse, error) {
@@ -216,7 +216,7 @@ func cmdWhy(adminURL string, args []string) {
 // --- aegisctl diff-policy ---
 
 type policyFile struct {
-	DefaultDecision string              `yaml:"default_decision"`
+	DefaultDecision string                `yaml:"default_decision"`
 	Rules           []toolpolicy.ToolRule `yaml:"rules"`
 }
 

--- a/cmd/aegisflow/main.go
+++ b/cmd/aegisflow/main.go
@@ -20,41 +20,42 @@ import (
 
 	"github.com/saivedant169/AegisFlow/internal/admin"
 	"github.com/saivedant169/AegisFlow/internal/analytics"
-	"github.com/saivedant169/AegisFlow/internal/behavioral"
+	"github.com/saivedant169/AegisFlow/internal/approval"
+	approvalint "github.com/saivedant169/AegisFlow/internal/approval/integrations"
 	"github.com/saivedant169/AegisFlow/internal/audit"
 	auditpg "github.com/saivedant169/AegisFlow/internal/audit/pgstore"
+	"github.com/saivedant169/AegisFlow/internal/behavioral"
 	"github.com/saivedant169/AegisFlow/internal/budget"
-	"github.com/saivedant169/AegisFlow/internal/costopt"
 	"github.com/saivedant169/AegisFlow/internal/cache"
+	"github.com/saivedant169/AegisFlow/internal/capability"
 	"github.com/saivedant169/AegisFlow/internal/config"
+	"github.com/saivedant169/AegisFlow/internal/costopt"
+	"github.com/saivedant169/AegisFlow/internal/credential"
 	"github.com/saivedant169/AegisFlow/internal/eval"
+	"github.com/saivedant169/AegisFlow/internal/evidence"
 	"github.com/saivedant169/AegisFlow/internal/federation"
 	"github.com/saivedant169/AegisFlow/internal/gateway"
 	"github.com/saivedant169/AegisFlow/internal/loadshed"
 	"github.com/saivedant169/AegisFlow/internal/logger"
+	"github.com/saivedant169/AegisFlow/internal/manifest"
+	"github.com/saivedant169/AegisFlow/internal/mcpgw"
 	"github.com/saivedant169/AegisFlow/internal/middleware"
 	"github.com/saivedant169/AegisFlow/internal/policy"
 	"github.com/saivedant169/AegisFlow/internal/provider"
-	"github.com/saivedant169/AegisFlow/internal/resilience"
 	"github.com/saivedant169/AegisFlow/internal/ratelimit"
+	"github.com/saivedant169/AegisFlow/internal/resilience"
 	"github.com/saivedant169/AegisFlow/internal/rollout"
 	rolloutpg "github.com/saivedant169/AegisFlow/internal/rollout/pgstore"
 	"github.com/saivedant169/AegisFlow/internal/router"
 	"github.com/saivedant169/AegisFlow/internal/storage"
 	"github.com/saivedant169/AegisFlow/internal/telemetry"
-	"github.com/saivedant169/AegisFlow/internal/approval"
-	approvalint "github.com/saivedant169/AegisFlow/internal/approval/integrations"
-	"github.com/saivedant169/AegisFlow/internal/capability"
-	"github.com/saivedant169/AegisFlow/internal/credential"
-	"github.com/saivedant169/AegisFlow/internal/evidence"
-	"github.com/saivedant169/AegisFlow/internal/usage"
-	"github.com/saivedant169/AegisFlow/internal/manifest"
-	"github.com/saivedant169/AegisFlow/internal/mcpgw"
 	"github.com/saivedant169/AegisFlow/internal/toolpolicy"
+	"github.com/saivedant169/AegisFlow/internal/usage"
 	"github.com/saivedant169/AegisFlow/internal/webhook"
 )
 
 const version = "v0.6.0"
+const defaultConfigFile = "configs/aegisflow.yaml"
 
 var totalRequests uint64
 
@@ -74,7 +75,7 @@ func (a *notifierAdapter) NotifyDenied(item *approval.ApprovalItem) error {
 }
 
 func main() {
-	configPath := flag.String("config", "configs/aegisflow.yaml", "path to config file")
+	configPath := flag.String("config", defaultConfigPath(), "path to config file")
 	showVersion := flag.Bool("version", false, "print aegisflow version")
 	flag.Parse()
 
@@ -827,6 +828,13 @@ func main() {
 	adminSrv.Shutdown(ctx)
 	handler.Close()
 	log.Println("servers stopped")
+}
+
+func defaultConfigPath() string {
+	if path := strings.TrimSpace(os.Getenv("AEGISFLOW_CONFIG")); path != "" {
+		return path
+	}
+	return defaultConfigFile
 }
 
 func healthHandler(w http.ResponseWriter, r *http.Request) {

--- a/cmd/aegisflow/main_test.go
+++ b/cmd/aegisflow/main_test.go
@@ -1,0 +1,19 @@
+package main
+
+import "testing"
+
+func TestDefaultConfigPathUsesFallback(t *testing.T) {
+	t.Setenv("AEGISFLOW_CONFIG", "")
+
+	if got := defaultConfigPath(); got != defaultConfigFile {
+		t.Fatalf("defaultConfigPath() = %q, want %q", got, defaultConfigFile)
+	}
+}
+
+func TestDefaultConfigPathUsesEnvironment(t *testing.T) {
+	t.Setenv("AEGISFLOW_CONFIG", " /etc/aegisflow/aegisflow.yaml ")
+
+	if got := defaultConfigPath(); got != "/etc/aegisflow/aegisflow.yaml" {
+		t.Fatalf("defaultConfigPath() = %q", got)
+	}
+}

--- a/deployments/helm/aegisflow/templates/deployment.yaml
+++ b/deployments/helm/aegisflow/templates/deployment.yaml
@@ -21,12 +21,15 @@ spec:
         - name: aegisflow
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: AEGISFLOW_CONFIG
+              value: /etc/aegisflow/aegisflow.yaml
           ports:
             - name: gateway
-              containerPort: 8080
+              containerPort: {{ .Values.service.gateway.port }}
               protocol: TCP
             - name: admin
-              containerPort: 8081
+              containerPort: {{ .Values.service.admin.port }}
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/examples/wasm-plugins/json-validator/main.go
+++ b/examples/wasm-plugins/json-validator/main.go
@@ -5,7 +5,8 @@
 // where a downstream tool expects JSON payloads.
 //
 // Build:
-//   GOOS=wasip1 GOARCH=wasm go build -o json-validator.wasm .
+//
+//	GOOS=wasip1 GOARCH=wasm go build -o json-validator.wasm .
 package main
 
 import (

--- a/examples/wasm-plugins/profanity-filter/main.go
+++ b/examples/wasm-plugins/profanity-filter/main.go
@@ -6,7 +6,8 @@
 // Unicode normalization, leet-speak decoding).
 //
 // Build:
-//   GOOS=wasip1 GOARCH=wasm go build -o profanity-filter.wasm .
+//
+//	GOOS=wasip1 GOARCH=wasm go build -o profanity-filter.wasm .
 package main
 
 import (

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -182,27 +182,27 @@ type ResilienceProvider interface {
 var dashboardHTML []byte
 
 type Server struct {
-	tracker    *usage.Tracker
-	cfg        *config.Config
-	registry   *provider.Registry
-	requestLog *RequestLog
-	cache              cache.Cache
-	rolloutMgr         RolloutManager
-	analyticsProvider  AnalyticsProvider
-	budgetProvider     BudgetProvider
-	auditProvider      AuditProvider
-	federationProvider FederationProvider
-	costOptProvider    CostOptProvider
-	evidenceProvider   EvidenceProvider
-	approvalProvider   ApprovalProvider
-	credentialProvider CredentialProvider
-	toolPolicyProvider   ToolPolicyProvider
-	manifestProvider     ManifestProvider
-	capabilityProvider   CapabilityProvider
-	supplyChainProvider  SupplyChainProvider
-	behavioralProvider      BehavioralProvider
-	resilienceProvider      ResilienceProvider
-	policyVersionProvider   PolicyVersionProvider
+	tracker               *usage.Tracker
+	cfg                   *config.Config
+	registry              *provider.Registry
+	requestLog            *RequestLog
+	cache                 cache.Cache
+	rolloutMgr            RolloutManager
+	analyticsProvider     AnalyticsProvider
+	budgetProvider        BudgetProvider
+	auditProvider         AuditProvider
+	federationProvider    FederationProvider
+	costOptProvider       CostOptProvider
+	evidenceProvider      EvidenceProvider
+	approvalProvider      ApprovalProvider
+	credentialProvider    CredentialProvider
+	toolPolicyProvider    ToolPolicyProvider
+	manifestProvider      ManifestProvider
+	capabilityProvider    CapabilityProvider
+	supplyChainProvider   SupplyChainProvider
+	behavioralProvider    BehavioralProvider
+	resilienceProvider    ResilienceProvider
+	policyVersionProvider PolicyVersionProvider
 }
 
 func NewServer(tracker *usage.Tracker, cfg *config.Config, registry *provider.Registry, reqLog *RequestLog, c cache.Cache, rm RolloutManager, ap AnalyticsProvider, bp BudgetProvider, aup AuditProvider, fp FederationProvider, cop CostOptProvider, ep EvidenceProvider, apvp ApprovalProvider, crp CredentialProvider, opts ...ServerOption) *Server {
@@ -534,13 +534,13 @@ func (s *Server) rolloutsCreateHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	var req createRolloutRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeAPIError(w, http.StatusBadRequest, "invalid_request", "invalid JSON: " + err.Error())
+		writeAPIError(w, http.StatusBadRequest, "invalid_request", "invalid JSON: "+err.Error())
 		return
 	}
 
 	obsWindow, err := time.ParseDuration(req.ObservationWindow)
 	if err != nil {
-		writeAPIError(w, http.StatusBadRequest, "invalid_request", "invalid observation_window: " + err.Error())
+		writeAPIError(w, http.StatusBadRequest, "invalid_request", "invalid observation_window: "+err.Error())
 		return
 	}
 
@@ -949,19 +949,19 @@ type testActionRequest struct {
 }
 
 type testActionResponse struct {
-	Decision              string      `json:"decision"`
-	EnvelopeID            string      `json:"envelope_id"`
-	EvidenceHash          string      `json:"evidence_hash"`
-	Message               string      `json:"message"`
-	ApprovalID            string      `json:"approval_id,omitempty"`
-	CredentialProvenance  interface{} `json:"credential_provenance,omitempty"`
-	DriftEvents           interface{} `json:"drift_events,omitempty"`
+	Decision             string      `json:"decision"`
+	EnvelopeID           string      `json:"envelope_id"`
+	EvidenceHash         string      `json:"evidence_hash"`
+	Message              string      `json:"message"`
+	ApprovalID           string      `json:"approval_id,omitempty"`
+	CredentialProvenance interface{} `json:"credential_provenance,omitempty"`
+	DriftEvents          interface{} `json:"drift_events,omitempty"`
 }
 
 func (s *Server) handleTestAction(w http.ResponseWriter, r *http.Request) {
 	var req testActionRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeAPIError(w, http.StatusBadRequest, "invalid_request", "invalid JSON: " + err.Error())
+		writeAPIError(w, http.StatusBadRequest, "invalid_request", "invalid JSON: "+err.Error())
 		return
 	}
 
@@ -1046,7 +1046,7 @@ func (s *Server) handleTestAction(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleSimulate(w http.ResponseWriter, r *http.Request) {
 	var req testActionRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeAPIError(w, http.StatusBadRequest, "invalid_request", "invalid JSON: " + err.Error())
+		writeAPIError(w, http.StatusBadRequest, "invalid_request", "invalid JSON: "+err.Error())
 		return
 	}
 
@@ -1104,7 +1104,7 @@ func (s *Server) handleActionWhy(w http.ResponseWriter, r *http.Request) {
 
 	trace, ok := actionTraceStore[id]
 	if !ok {
-		writeAPIError(w, http.StatusNotFound, "not_found", "no trace found for action " + id)
+		writeAPIError(w, http.StatusNotFound, "not_found", "no trace found for action "+id)
 		return
 	}
 
@@ -1172,7 +1172,7 @@ func (s *Server) handleManifestCreate(w http.ResponseWriter, r *http.Request) {
 
 	var req createManifestRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeAPIError(w, http.StatusBadRequest, "invalid_request", "invalid JSON: " + err.Error())
+		writeAPIError(w, http.StatusBadRequest, "invalid_request", "invalid JSON: "+err.Error())
 		return
 	}
 
@@ -1434,7 +1434,7 @@ func (s *Server) handlePolicyVersionRollback(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	json.NewEncoder(w).Encode(map[string]interface{}{
-		"status":              "ok",
-		"rolled_back_to":      version,
+		"status":         "ok",
+		"rolled_back_to": version,
 	})
 }

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -108,13 +108,13 @@ func newIntegrationAdminServer() *Server {
 // --- Stub providers for testing ---
 
 type stubApprovalProvider struct {
-	pendingItems  []map[string]interface{}
-	historyItems  []map[string]interface{}
-	approveErr    error
-	denyErr       error
+	pendingItems []map[string]interface{}
+	historyItems []map[string]interface{}
+	approveErr   error
+	denyErr      error
 }
 
-func (s *stubApprovalProvider) Pending() interface{} { return s.pendingItems }
+func (s *stubApprovalProvider) Pending() interface{}          { return s.pendingItems }
 func (s *stubApprovalProvider) History(limit int) interface{} { return s.historyItems }
 func (s *stubApprovalProvider) Get(id string) (interface{}, error) {
 	for _, item := range s.pendingItems {

--- a/internal/admin/graphql_test.go
+++ b/internal/admin/graphql_test.go
@@ -47,16 +47,16 @@ func newGraphQLTestServer() *Server {
 		cfg,
 		registry,
 		NewRequestLog(10),
-		nil,                       // cache
-		&stubRolloutManager{},     // rollout
-		&stubAnalyticsProvider{},  // analytics
-		nil,                       // budget
+		nil,                        // cache
+		&stubRolloutManager{},      // rollout
+		&stubAnalyticsProvider{},   // analytics
+		nil,                        // budget
 		&verifyOnlyAuditProvider{}, // audit
-		nil,                       // federation
-		nil,                       // costopt
-		nil,                       // evidence
-		nil,                       // approval
-		nil,                       // credential
+		nil,                        // federation
+		nil,                        // costopt
+		nil,                        // evidence
+		nil,                        // approval
+		nil,                        // credential
 	)
 }
 

--- a/internal/analytics/alerts.go
+++ b/internal/analytics/alerts.go
@@ -10,12 +10,12 @@ import (
 
 type AlertManager struct {
 	mu             sync.RWMutex
-	active         map[string]*Alert  // keyed by dimension+metric
-	history        []*Alert           // resolved alerts
+	active         map[string]*Alert // keyed by dimension+metric
+	history        []*Alert          // resolved alerts
 	maxHistory     int
 	webhook        *webhook.Notifier
-	normalCounters map[string]int     // consecutive normal evaluations per dimension+metric
-	resolveAfter   int                // consecutive normal evals before auto-resolve
+	normalCounters map[string]int // consecutive normal evaluations per dimension+metric
+	resolveAfter   int            // consecutive normal evals before auto-resolve
 }
 
 func NewAlertManager(wh *webhook.Notifier) *AlertManager {

--- a/internal/behavioral/engine.go
+++ b/internal/behavioral/engine.go
@@ -10,14 +10,14 @@ import (
 // SessionAnalyzer tracks action history per session and runs behavioral
 // detection rules over action sequences to detect risky patterns.
 type SessionAnalyzer struct {
-	mu             sync.RWMutex
-	sessionID      string
-	history        []envelope.ActionEnvelope
-	alerts         []BehaviorAlert
-	rules          []Rule
+	mu              sync.RWMutex
+	sessionID       string
+	history         []envelope.ActionEnvelope
+	alerts          []BehaviorAlert
+	rules           []Rule
 	killSwitchScore int
-	windowMinutes  int
-	blocked        bool
+	windowMinutes   int
+	blocked         bool
 }
 
 // NewSessionAnalyzer creates a new analyzer for a given session.

--- a/internal/behavioral/rules.go
+++ b/internal/behavioral/rules.go
@@ -18,7 +18,7 @@ type Rule interface {
 // POSTs data to an external host.
 type ExfiltrationPattern struct{}
 
-func (r ExfiltrationPattern) Name() string        { return "exfiltration_pattern" }
+func (r ExfiltrationPattern) Name() string { return "exfiltration_pattern" }
 func (r ExfiltrationPattern) Description() string {
 	return "Read sensitive resource then POST to external host"
 }
@@ -60,7 +60,7 @@ func (r ExfiltrationPattern) Detect(history []envelope.ActionEnvelope) *Behavior
 // PrivilegeEscalation detects when a session edits workflow/CI files then pushes or deploys.
 type PrivilegeEscalation struct{}
 
-func (r PrivilegeEscalation) Name() string        { return "privilege_escalation" }
+func (r PrivilegeEscalation) Name() string { return "privilege_escalation" }
 func (r PrivilegeEscalation) Description() string {
 	return "Edit workflow or CI configuration then push or deploy"
 }
@@ -102,7 +102,7 @@ func (r PrivilegeEscalation) Detect(history []envelope.ActionEnvelope) *Behavior
 // CredentialAbuse detects when a session reads secrets then makes multiple external calls.
 type CredentialAbuse struct{}
 
-func (r CredentialAbuse) Name() string        { return "credential_abuse" }
+func (r CredentialAbuse) Name() string { return "credential_abuse" }
 func (r CredentialAbuse) Description() string {
 	return "Read secrets then make multiple external calls"
 }
@@ -151,7 +151,7 @@ type DestructiveSequence struct {
 	Threshold int // number of consecutive deletes; defaults to 3
 }
 
-func (r DestructiveSequence) Name() string        { return "destructive_sequence" }
+func (r DestructiveSequence) Name() string { return "destructive_sequence" }
 func (r DestructiveSequence) Description() string {
 	return "Multiple delete operations in sequence"
 }
@@ -189,11 +189,11 @@ func (r DestructiveSequence) Detect(history []envelope.ActionEnvelope) *Behavior
 
 // SuspiciousFanOut detects a single session hitting many different targets rapidly.
 type SuspiciousFanOut struct {
-	MaxTargets    int           // threshold; defaults to 10
-	WindowSeconds int           // time window in seconds; defaults to 60
+	MaxTargets    int // threshold; defaults to 10
+	WindowSeconds int // time window in seconds; defaults to 60
 }
 
-func (r SuspiciousFanOut) Name() string        { return "suspicious_fan_out" }
+func (r SuspiciousFanOut) Name() string { return "suspicious_fan_out" }
 func (r SuspiciousFanOut) Description() string {
 	return "Single session hitting many different targets rapidly"
 }
@@ -247,7 +247,7 @@ type RepeatedEscalation struct {
 	WindowSeconds int // time window in seconds; defaults to 300 (5 min)
 }
 
-func (r RepeatedEscalation) Name() string        { return "repeated_escalation" }
+func (r RepeatedEscalation) Name() string { return "repeated_escalation" }
 func (r RepeatedEscalation) Description() string {
 	return "Multiple review or approval requests in short time"
 }

--- a/internal/budget/budget.go
+++ b/internal/budget/budget.go
@@ -7,8 +7,8 @@ import (
 )
 
 type SpendScope struct {
-	Scope   string  // "global", "tenant", "tenant_model"
-	ScopeID string  // "global", "premium", "premium:gpt-4o"
+	Scope   string // "global", "tenant", "tenant_model"
+	ScopeID string // "global", "premium", "premium:gpt-4o"
 	Limit   float64
 	AlertAt int // percentage
 	WarnAt  int // percentage

--- a/internal/cache/semantic_test.go
+++ b/internal/cache/semantic_test.go
@@ -133,8 +133,8 @@ func TestSemanticCacheStats(t *testing.T) {
 	sc := NewSemanticCache(newTestEmbedder(), 0.85, 100)
 
 	sc.SetSemantic("t1", makeReq("hello"), makeResp("world"))
-	sc.GetSemantic("t1", makeReq("hello"))     // hit
-	sc.GetSemantic("t1", makeReq("goodbye"))    // miss
+	sc.GetSemantic("t1", makeReq("hello"))   // hit
+	sc.GetSemantic("t1", makeReq("goodbye")) // miss
 
 	stats := sc.Stats()
 	if stats.Hits != 1 {

--- a/internal/capability/issuer_test.go
+++ b/internal/capability/issuer_test.go
@@ -11,17 +11,17 @@ func testKey() []byte {
 
 func validRequest() TicketRequest {
 	return TicketRequest{
-		Subject:    "agent-007",
-		TaskID:     "task-123",
-		SessionID:  "session-abc",
-		EnvelopeID: "env-456",
-		Resource:   "repos/acme/widget",
-		Verb:       "write",
-		Protocol:   "http",
-		Tool:       "github",
-		PolicyHash: "abc123policydef",
+		Subject:     "agent-007",
+		TaskID:      "task-123",
+		SessionID:   "session-abc",
+		EnvelopeID:  "env-456",
+		Resource:    "repos/acme/widget",
+		Verb:        "write",
+		Protocol:    "http",
+		Tool:        "github",
+		PolicyHash:  "abc123policydef",
 		EvidenceRef: "evidence-xyz",
-		TTL:        5 * time.Minute,
+		TTL:         5 * time.Minute,
 	}
 }
 

--- a/internal/capability/ticket.go
+++ b/internal/capability/ticket.go
@@ -12,21 +12,21 @@ import (
 // Ticket is a signed, one-purpose execution capability.
 type Ticket struct {
 	ID           string    `json:"id"`
-	Subject      string    `json:"subject"`                // agent/user ID
+	Subject      string    `json:"subject"` // agent/user ID
 	TaskID       string    `json:"task_id"`
 	SessionID    string    `json:"session_id"`
-	EnvelopeID   string    `json:"envelope_id"`             // the action this authorizes
-	Resource     string    `json:"resource"`                // exact resource
-	Verb         string    `json:"verb"`                    // exact verb
+	EnvelopeID   string    `json:"envelope_id"` // the action this authorizes
+	Resource     string    `json:"resource"`    // exact resource
+	Verb         string    `json:"verb"`        // exact verb
 	Protocol     string    `json:"protocol"`
 	Tool         string    `json:"tool"`
 	PolicyHash   string    `json:"policy_hash"`             // hash of the policy that authorized this
 	ApprovalHash string    `json:"approval_hash,omitempty"` // hash of approval if review path
 	IssuedAt     time.Time `json:"issued_at"`
 	ExpiresAt    time.Time `json:"expires_at"`
-	Nonce        string    `json:"nonce"`          // replay protection
-	EvidenceRef  string    `json:"evidence_ref"`   // evidence chain pointer
-	Signature    string    `json:"signature"`      // HMAC-SHA256 signature
+	Nonce        string    `json:"nonce"`        // replay protection
+	EvidenceRef  string    `json:"evidence_ref"` // evidence chain pointer
+	Signature    string    `json:"signature"`    // HMAC-SHA256 signature
 }
 
 // TicketRequest describes the parameters needed to issue a capability ticket.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,43 +5,44 @@ import (
 	"crypto/subtle"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
 )
 
 type Config struct {
-	Server     ServerConfig     `yaml:"server"`
-	Providers  []ProviderConfig `yaml:"providers"`
-	Routes     []RouteConfig    `yaml:"routes"`
-	Tenants    []TenantConfig   `yaml:"tenants"`
-	RateLimit  RateLimitConfig  `yaml:"rate_limit"`
-	Policies   PoliciesConfig   `yaml:"policies"`
-	Telemetry  TelemetryConfig  `yaml:"telemetry"`
-	Logging    LoggingConfig    `yaml:"logging"`
-	Cache      CacheConfig      `yaml:"cache"`
-	Webhook    WebhookConfig    `yaml:"webhook"`
-	Database   DatabaseConfig   `yaml:"database"`
-	Admin      AdminConfig      `yaml:"admin"`
-	Aliases    AliasConfig      `yaml:"aliases"`
-	Transform  TransformConfig  `yaml:"transform"`
-	Analytics  AnalyticsConfig  `yaml:"analytics"`
-	Budgets    BudgetsConfig    `yaml:"budgets"`
-	CostOpt    CostOptConfig    `yaml:"cost_optimization"`
-	Eval       EvalConfig       `yaml:"eval"`
-	Federation FederationConfig `yaml:"federation"`
-	LoadShed     LoadShedConfig   `yaml:"load_shed"`
-	WebSocket    WebSocketConfig  `yaml:"websocket"`
-	ToolPolicies ToolPolicyConfig `yaml:"tool_policies"`
-	MCPGateway   MCPGatewayConfig   `yaml:"mcp_gateway"`
-	Credentials  CredentialConfig   `yaml:"credentials"`
-	ShellGate    ShellGateConfig    `yaml:"shell_gate"`
-	SQLGate      SQLGateConfig      `yaml:"sql_gate"`
-	GitHubGate   GitHubGateConfig   `yaml:"github_gate"`
-	HTTPGate     HTTPGateConfig     `yaml:"http_gate"`
-	Sandbox          SandboxConfig        `yaml:"sandbox"`
-	Capability       CapabilityConfig     `yaml:"capability"`
-	ResourcePolicies ResourcePolicyConfig `yaml:"resource_policies"`
+	Server               ServerConfig              `yaml:"server"`
+	Providers            []ProviderConfig          `yaml:"providers"`
+	Routes               []RouteConfig             `yaml:"routes"`
+	Tenants              []TenantConfig            `yaml:"tenants"`
+	RateLimit            RateLimitConfig           `yaml:"rate_limit"`
+	Policies             PoliciesConfig            `yaml:"policies"`
+	Telemetry            TelemetryConfig           `yaml:"telemetry"`
+	Logging              LoggingConfig             `yaml:"logging"`
+	Cache                CacheConfig               `yaml:"cache"`
+	Webhook              WebhookConfig             `yaml:"webhook"`
+	Database             DatabaseConfig            `yaml:"database"`
+	Admin                AdminConfig               `yaml:"admin"`
+	Aliases              AliasConfig               `yaml:"aliases"`
+	Transform            TransformConfig           `yaml:"transform"`
+	Analytics            AnalyticsConfig           `yaml:"analytics"`
+	Budgets              BudgetsConfig             `yaml:"budgets"`
+	CostOpt              CostOptConfig             `yaml:"cost_optimization"`
+	Eval                 EvalConfig                `yaml:"eval"`
+	Federation           FederationConfig          `yaml:"federation"`
+	LoadShed             LoadShedConfig            `yaml:"load_shed"`
+	WebSocket            WebSocketConfig           `yaml:"websocket"`
+	ToolPolicies         ToolPolicyConfig          `yaml:"tool_policies"`
+	MCPGateway           MCPGatewayConfig          `yaml:"mcp_gateway"`
+	Credentials          CredentialConfig          `yaml:"credentials"`
+	ShellGate            ShellGateConfig           `yaml:"shell_gate"`
+	SQLGate              SQLGateConfig             `yaml:"sql_gate"`
+	GitHubGate           GitHubGateConfig          `yaml:"github_gate"`
+	HTTPGate             HTTPGateConfig            `yaml:"http_gate"`
+	Sandbox              SandboxConfig             `yaml:"sandbox"`
+	Capability           CapabilityConfig          `yaml:"capability"`
+	ResourcePolicies     ResourcePolicyConfig      `yaml:"resource_policies"`
 	Manifests            ManifestConfig            `yaml:"manifests"`
 	ApprovalIntegrations ApprovalIntegrationConfig `yaml:"approval_integrations"`
 	Identity             IdentityConfig            `yaml:"identity"`
@@ -54,16 +55,16 @@ type Config struct {
 type SupplyChainConfig struct {
 	Enabled    bool   `yaml:"enabled"`
 	StrictMode bool   `yaml:"strict_mode"` // reject unsigned in strict
-	SigningKey  string `yaml:"signing_key"` // hex-encoded HMAC key
+	SigningKey string `yaml:"signing_key"` // hex-encoded HMAC key
 }
 
 // ResilienceConfig controls enterprise resilience features: health monitoring,
 // degradation modes, retention, backup, and circuit breakers.
 type ResilienceConfig struct {
-	Enabled        bool                `yaml:"enabled"`
-	HealthInterval time.Duration       `yaml:"health_interval"`
-	Retention      RetentionPolicyCfg  `yaml:"retention"`
-	BackupDir      string              `yaml:"backup_dir"`
+	Enabled        bool                 `yaml:"enabled"`
+	HealthInterval time.Duration        `yaml:"health_interval"`
+	Retention      RetentionPolicyCfg   `yaml:"retention"`
+	BackupDir      string               `yaml:"backup_dir"`
 	CircuitBreaker CircuitBreakerConfig `yaml:"circuit_breaker"`
 }
 
@@ -91,9 +92,9 @@ type BehavioralConfig struct {
 
 // ApprovalIntegrationConfig configures external approval notification channels.
 type ApprovalIntegrationConfig struct {
-	Timeout time.Duration          `yaml:"timeout"` // auto-deny after this duration
-	GitHub  GitHubApprovalConfig   `yaml:"github"`
-	Slack   SlackApprovalConfig    `yaml:"slack"`
+	Timeout time.Duration        `yaml:"timeout"` // auto-deny after this duration
+	GitHub  GitHubApprovalConfig `yaml:"github"`
+	Slack   SlackApprovalConfig  `yaml:"slack"`
 }
 
 // GitHubApprovalConfig enables posting approval requests as PR comments.
@@ -218,7 +219,7 @@ type CredentialConfig struct {
 
 type CredentialProviderCfg struct {
 	Name            string        `yaml:"name"`
-	Type            string        `yaml:"type"` // "static", "github_app", "vault", "aws_sts"
+	Type            string        `yaml:"type"`  // "static", "github_app", "vault", "aws_sts"
 	Token           string        `yaml:"token"` // for static
 	GitHubAppID     int64         `yaml:"github_app_id"`
 	GitHubKeyPath   string        `yaml:"github_key_path"`
@@ -240,10 +241,9 @@ type ShellGateConfig struct {
 
 type SQLGateConfig struct {
 	Enabled         bool   `yaml:"enabled"`
-	BlockDangerous  bool   `yaml:"block_dangerous"`  // auto-block DROP, TRUNCATE, WHERE-less DELETE/UPDATE
+	BlockDangerous  bool   `yaml:"block_dangerous"` // auto-block DROP, TRUNCATE, WHERE-less DELETE/UPDATE
 	DefaultDecision string `yaml:"default_decision"`
 }
-
 
 // SandboxConfig holds architectural safety constraints for all protocol gates.
 type SandboxConfig struct {
@@ -254,14 +254,14 @@ type SandboxConfig struct {
 }
 
 type ShellSandboxConfig struct {
-	AllowedBinaries []string             `yaml:"allowed_binaries"`
-	BlockedBinaries []string             `yaml:"blocked_binaries"`
-	AllowedPaths    []string             `yaml:"allowed_paths"`
-	BlockedPaths    []string             `yaml:"blocked_paths"`
-	NetworkPolicy   NetworkPolicyConfig  `yaml:"network_policy"`
-	MaxDuration     string               `yaml:"max_duration"`
-	MaxOutputBytes  int64                `yaml:"max_output_bytes"`
-	EnvRedactions   []string             `yaml:"env_redactions"`
+	AllowedBinaries []string            `yaml:"allowed_binaries"`
+	BlockedBinaries []string            `yaml:"blocked_binaries"`
+	AllowedPaths    []string            `yaml:"allowed_paths"`
+	BlockedPaths    []string            `yaml:"blocked_paths"`
+	NetworkPolicy   NetworkPolicyConfig `yaml:"network_policy"`
+	MaxDuration     string              `yaml:"max_duration"`
+	MaxOutputBytes  int64               `yaml:"max_output_bytes"`
+	EnvRedactions   []string            `yaml:"env_redactions"`
 }
 
 type NetworkPolicyConfig struct {
@@ -957,6 +957,12 @@ func validateConfig(cfg *Config) error {
 
 	// --- Tenants ---
 	tenantIDs := make(map[string]bool, len(cfg.Tenants))
+	apiKeys := make(map[string]string)
+	validRoles := map[string]bool{
+		"viewer":   true,
+		"operator": true,
+		"admin":    true,
+	}
 	for i, tenant := range cfg.Tenants {
 		if tenant.ID == "" {
 			return fmt.Errorf("tenants[%d]: tenant id must not be empty", i)
@@ -967,6 +973,19 @@ func validateConfig(cfg *Config) error {
 		tenantIDs[tenant.ID] = true
 		if len(tenant.APIKeys) == 0 {
 			return fmt.Errorf("tenant %q: api_keys must not be empty", tenant.ID)
+		}
+		for j, entry := range tenant.APIKeys {
+			key := strings.TrimSpace(entry.Key)
+			if key == "" {
+				return fmt.Errorf("tenant %q api_keys[%d]: key must not be empty", tenant.ID, j)
+			}
+			if !validRoles[entry.Role] {
+				return fmt.Errorf("tenant %q api_keys[%d]: role %q must be one of viewer, operator, admin", tenant.ID, j, entry.Role)
+			}
+			if owner, exists := apiKeys[key]; exists {
+				return fmt.Errorf("tenant %q api_keys[%d]: duplicate api key already used by tenant %q", tenant.ID, j, owner)
+			}
+			apiKeys[key] = tenant.ID
 		}
 		if tenant.RateLimit.RequestsPerMinute < 0 {
 			return fmt.Errorf("tenant %q: requests_per_minute must not be negative", tenant.ID)

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -109,6 +109,42 @@ tenants:
 `, "api_keys")
 }
 
+func TestValidateTenantEmptyAPIKey(t *testing.T) {
+	expectValidationError(t, `
+tenants:
+  - id: "t1"
+    name: "Empty Key"
+    api_keys:
+      - key: ""
+        role: "operator"
+`, "key must not be empty")
+}
+
+func TestValidateTenantDuplicateAPIKeys(t *testing.T) {
+	expectValidationError(t, `
+tenants:
+  - id: "t1"
+    name: "Tenant A"
+    api_keys: ["shared-key"]
+  - id: "t2"
+    name: "Tenant B"
+    api_keys:
+      - key: "shared-key"
+        role: "admin"
+`, "duplicate api key")
+}
+
+func TestValidateTenantInvalidAPIKeyRole(t *testing.T) {
+	expectValidationError(t, `
+tenants:
+  - id: "t1"
+    name: "Bad Role"
+    api_keys:
+      - key: "key-a"
+        role: "owner"
+`, "must be one of viewer, operator, admin")
+}
+
 func TestValidateDuplicateTenantIDs(t *testing.T) {
 	expectValidationError(t, `
 tenants:

--- a/internal/credential/aws_sts.go
+++ b/internal/credential/aws_sts.go
@@ -22,7 +22,7 @@ import (
 // STSCredentials holds the temporary credentials returned by STS AssumeRole.
 type STSCredentials struct {
 	AccessKeyID     string
-	SecretAccessKey  string
+	SecretAccessKey string
 	SessionToken    string
 	Expiration      time.Time
 }
@@ -326,7 +326,7 @@ func parseAssumeRoleResponse(data []byte) (*STSCredentials, error) {
 
 	return &STSCredentials{
 		AccessKeyID:     resp.Result.Credentials.AccessKeyId,
-		SecretAccessKey:  resp.Result.Credentials.SecretAccessKey,
+		SecretAccessKey: resp.Result.Credentials.SecretAccessKey,
 		SessionToken:    resp.Result.Credentials.SessionToken,
 		Expiration:      expiration,
 	}, nil

--- a/internal/credential/aws_sts_test.go
+++ b/internal/credential/aws_sts_test.go
@@ -254,7 +254,7 @@ func TestSanitizeSessionName(t *testing.T) {
 	}{
 		{"aegisflow-task-123", "aegisflow-task-123"},
 		{"aegis flow!task#123", "aegisflowtask123"},
-		{"a", "aegisflow-session"}, // too short
+		{"a", "aegisflow-session"},                          // too short
 		{strings.Repeat("a", 100), strings.Repeat("a", 64)}, // too long
 	}
 	for _, tt := range tests {

--- a/internal/credential/broker.go
+++ b/internal/credential/broker.go
@@ -8,11 +8,11 @@ import (
 // Credential represents a short-lived, task-scoped credential issued by a broker.
 type Credential struct {
 	ID        string    `json:"id"`
-	Type      string    `json:"type"`       // "github_app", "aws_sts", "vault", "static"
-	Token     string    `json:"token"`      // the actual credential value
+	Type      string    `json:"type"`  // "github_app", "aws_sts", "vault", "static"
+	Token     string    `json:"token"` // the actual credential value
 	ExpiresAt time.Time `json:"expires_at"`
-	Scope     string    `json:"scope"`      // what this credential can access
-	TaskID    string    `json:"task_id"`    // which task/session this was issued for
+	Scope     string    `json:"scope"`   // what this credential can access
+	TaskID    string    `json:"task_id"` // which task/session this was issued for
 	IssuedAt  time.Time `json:"issued_at"`
 }
 

--- a/internal/credential/github.go
+++ b/internal/credential/github.go
@@ -22,14 +22,14 @@ import (
 
 // GitHubAppBroker issues short-lived installation access tokens via the GitHub App API.
 type GitHubAppBroker struct {
-	name          string
-	appID         int64
-	keyPath       string
-	installID     int64
-	defaultTTL    time.Duration
-	client        *http.Client
-	baseURL       string // defaults to "https://api.github.com"; override for testing
-	jwtFn         func() (string, error) // produces a JWT; injectable for testing
+	name       string
+	appID      int64
+	keyPath    string
+	installID  int64
+	defaultTTL time.Duration
+	client     *http.Client
+	baseURL    string                 // defaults to "https://api.github.com"; override for testing
+	jwtFn      func() (string, error) // produces a JWT; injectable for testing
 
 	mu      sync.Mutex
 	revoked map[string]bool
@@ -277,4 +277,3 @@ func splitJWT(token string) []string {
 	}
 	return parts
 }
-

--- a/internal/envelope/envelope.go
+++ b/internal/envelope/envelope.go
@@ -13,26 +13,26 @@ import (
 
 // ActionEnvelope normalizes every agent action into a policy-evaluable object.
 type ActionEnvelope struct {
-	ID                  string         `json:"id"`
-	Timestamp           time.Time      `json:"timestamp"`
-	Actor               ActorInfo      `json:"actor"`
-	Task                string         `json:"task"`
-	Protocol            Protocol       `json:"protocol"`
-	Tool                string         `json:"tool"`
-	Target              string         `json:"target"`
-	Parameters          map[string]any `json:"parameters"`
-	RequestedCapability Capability     `json:"requested_capability"`
+	ID                  string             `json:"id"`
+	Timestamp           time.Time          `json:"timestamp"`
+	Actor               ActorInfo          `json:"actor"`
+	Task                string             `json:"task"`
+	Protocol            Protocol           `json:"protocol"`
+	Tool                string             `json:"tool"`
+	Target              string             `json:"target"`
+	Parameters          map[string]any     `json:"parameters"`
+	RequestedCapability Capability         `json:"requested_capability"`
 	Resource            *resource.Resource `json:"resource,omitempty"`
 	CredentialRef       string             `json:"credential_ref,omitempty"`
 	PolicyDecision      Decision           `json:"policy_decision"`
-	EvidenceHash        string         `json:"evidence_hash,omitempty"`
-	Justification       string         `json:"justification,omitempty"`
-	Result              *ActionResult  `json:"result,omitempty"`
+	EvidenceHash        string             `json:"evidence_hash,omitempty"`
+	Justification       string             `json:"justification,omitempty"`
+	Result              *ActionResult      `json:"result,omitempty"`
 }
 
 // ActorInfo identifies the entity performing the action.
 type ActorInfo struct {
-	Type      string `json:"type"`       // "user", "agent", "service"
+	Type      string `json:"type"` // "user", "agent", "service"
 	ID        string `json:"id"`
 	SessionID string `json:"session_id"`
 	TenantID  string `json:"tenant_id"`

--- a/internal/envelope/envelope_test.go
+++ b/internal/envelope/envelope_test.go
@@ -86,7 +86,7 @@ func TestHashChangesWhenContentChanges(t *testing.T) {
 
 func TestIsDestructive(t *testing.T) {
 	tests := []struct {
-		cap        Capability
+		cap         Capability
 		destructive bool
 	}{
 		{CapRead, false},

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -15,8 +15,8 @@ import (
 	"github.com/saivedant169/AegisFlow/internal/admin"
 	"github.com/saivedant169/AegisFlow/internal/analytics"
 	"github.com/saivedant169/AegisFlow/internal/behavioral"
-	"github.com/saivedant169/AegisFlow/internal/envelope"
 	"github.com/saivedant169/AegisFlow/internal/cache"
+	"github.com/saivedant169/AegisFlow/internal/envelope"
 	"github.com/saivedant169/AegisFlow/internal/eval"
 	"github.com/saivedant169/AegisFlow/internal/middleware"
 	"github.com/saivedant169/AegisFlow/internal/policy"
@@ -29,22 +29,22 @@ import (
 )
 
 type Handler struct {
-	registry       *provider.Registry
-	router         *router.Router
-	policy         *policy.Engine
-	usage          *usage.Tracker
-	cache          cache.Cache
-	webhook        *webhook.Notifier
-	store          *storage.PostgresStore
-	dbQueue        chan storage.UsageEvent
-	analytics      *analytics.Collector
-	maxBodySize    int64
-	recordSpend    func(tenantID, model string, cost float64)
-	budgetCheck    func(tenantID, model string) (bool, []string, string)
-	evalBuiltin    bool
-	evalMinTokens  int
-	evalLatencyMul float64
-	evalWebhook    *eval.WebhookEvaluator
+	registry             *provider.Registry
+	router               *router.Router
+	policy               *policy.Engine
+	usage                *usage.Tracker
+	cache                cache.Cache
+	webhook              *webhook.Notifier
+	store                *storage.PostgresStore
+	dbQueue              chan storage.UsageEvent
+	analytics            *analytics.Collector
+	maxBodySize          int64
+	recordSpend          func(tenantID, model string, cost float64)
+	budgetCheck          func(tenantID, model string) (bool, []string, string)
+	evalBuiltin          bool
+	evalMinTokens        int
+	evalLatencyMul       float64
+	evalWebhook          *eval.WebhookEvaluator
 	auditLog             func(actor, actorRole, action, resource, detail, tenantID, model string)
 	requestLog           *admin.RequestLog
 	dataPlaneName        string

--- a/internal/gateway/transform.go
+++ b/internal/gateway/transform.go
@@ -9,9 +9,9 @@ import (
 
 // TransformConfig holds request transformation rules.
 type TransformConfig struct {
-	SystemPromptPrefix string            // Prepend to system message
-	SystemPromptSuffix string            // Append to system message
-	DefaultSystemPrompt string           // Use if no system message exists
+	SystemPromptPrefix  string            // Prepend to system message
+	SystemPromptSuffix  string            // Append to system message
+	DefaultSystemPrompt string            // Use if no system message exists
 	HeaderInjections    map[string]string // Extra metadata to inject
 }
 
@@ -87,9 +87,9 @@ func mergeTransformConfig(global, tenant *TransformConfig) *TransformConfig {
 
 // ResponseTransformConfig holds response transformation rules.
 type ResponseTransformConfig struct {
-	StripPII     bool              // Replace PII patterns with placeholders
-	ContentSuffix string           // Append to response content
-	ContentPrefix string           // Prepend to response content
+	StripPII      bool              // Replace PII patterns with placeholders
+	ContentSuffix string            // Append to response content
+	ContentPrefix string            // Prepend to response content
 	Replacements  map[string]string // Literal string replacements
 }
 

--- a/internal/githubgate/operations.go
+++ b/internal/githubgate/operations.go
@@ -46,8 +46,8 @@ var knownOperations = map[string]operationInfo{
 	"create_release":      {envelope.CapWrite, RiskMedium},
 
 	// Deploy operations — high risk
-	"merge_pull_request":  {envelope.CapDeploy, RiskHigh},
-	"create_deployment":   {envelope.CapDeploy, RiskHigh},
+	"merge_pull_request": {envelope.CapDeploy, RiskHigh},
+	"create_deployment":  {envelope.CapDeploy, RiskHigh},
 	"push":               {envelope.CapDeploy, RiskHigh},
 
 	// Delete operations — critical risk

--- a/internal/identity/model.go
+++ b/internal/identity/model.go
@@ -23,7 +23,7 @@ type Project struct {
 // Environment belongs to a Project and carries a risk tier.
 type Environment struct {
 	ID        string `json:"id" yaml:"id"`
-	Name      string `json:"name" yaml:"name"`             // dev, staging, prod
+	Name      string `json:"name" yaml:"name"` // dev, staging, prod
 	ProjectID string `json:"project_id" yaml:"project_id"`
 	RiskTier  string `json:"risk_tier" yaml:"risk_tier"` // low, medium, high, critical
 }

--- a/internal/loadshed/shedder.go
+++ b/internal/loadshed/shedder.go
@@ -36,9 +36,9 @@ type Config struct {
 
 // Shedder manages admission control with priority-based load shedding.
 type Shedder struct {
-	cfg       Config
-	inflight  atomic.Int64
-	queue     chan struct{} // buffered channel used as a semaphore for queued slots
+	cfg      Config
+	inflight atomic.Int64
+	queue    chan struct{} // buffered channel used as a semaphore for queued slots
 }
 
 // New creates a new Shedder with the given configuration.

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -10,9 +10,9 @@ import (
 // TaskManifest declares what an agent session intends to do.
 type TaskManifest struct {
 	ID               string    `json:"id"`
-	TaskID           string    `json:"task_id"`           // ticket/issue/runbook reference
+	TaskID           string    `json:"task_id"` // ticket/issue/runbook reference
 	Description      string    `json:"description"`
-	Owner            string    `json:"owner"`             // human sponsor
+	Owner            string    `json:"owner"` // human sponsor
 	CreatedAt        time.Time `json:"created_at"`
 	ExpiresAt        time.Time `json:"expires_at"`
 	AllowedTools     []string  `json:"allowed_tools"`     // glob patterns

--- a/internal/policy/engine_test.go
+++ b/internal/policy/engine_test.go
@@ -321,8 +321,8 @@ type errorFilter struct {
 	name string
 }
 
-func (f *errorFilter) Name() string       { return f.name }
-func (f *errorFilter) Action() Action     { return ActionBlock }
+func (f *errorFilter) Name() string            { return f.name }
+func (f *errorFilter) Action() Action          { return ActionBlock }
 func (f *errorFilter) Check(string) *Violation { return nil }
 func (f *errorFilter) CheckE(string) (*Violation, error) {
 	return nil, fmt.Errorf("simulated filter failure")

--- a/internal/provider/anthropic.go
+++ b/internal/provider/anthropic.go
@@ -34,12 +34,12 @@ type anthropicMessage struct {
 }
 
 type anthropicResponse struct {
-	ID      string                   `json:"id"`
-	Type    string                   `json:"type"`
-	Role    string                   `json:"role"`
-	Content []anthropicContentBlock  `json:"content"`
-	Model   string                   `json:"model"`
-	Usage   anthropicUsage           `json:"usage"`
+	ID      string                  `json:"id"`
+	Type    string                  `json:"type"`
+	Role    string                  `json:"role"`
+	Content []anthropicContentBlock `json:"content"`
+	Model   string                  `json:"model"`
+	Usage   anthropicUsage          `json:"usage"`
 }
 
 type anthropicContentBlock struct {

--- a/internal/provider/bedrock.go
+++ b/internal/provider/bedrock.go
@@ -31,12 +31,12 @@ type BedrockProvider struct {
 }
 
 type bedrockRequest struct {
-	Messages []bedrockMessage `json:"messages"`
+	Messages        []bedrockMessage        `json:"messages"`
 	InferenceConfig *bedrockInferenceConfig `json:"inferenceConfig,omitempty"`
 }
 
 type bedrockMessage struct {
-	Role    string          `json:"role"`
+	Role    string           `json:"role"`
 	Content []bedrockContent `json:"content"`
 }
 

--- a/internal/provider/gemini.go
+++ b/internal/provider/gemini.go
@@ -27,7 +27,7 @@ type GeminiProvider struct {
 }
 
 type geminiRequest struct {
-	Contents         []geminiContent        `json:"contents"`
+	Contents         []geminiContent         `json:"contents"`
 	GenerationConfig *geminiGenerationConfig `json:"generationConfig,omitempty"`
 }
 
@@ -47,8 +47,8 @@ type geminiGenerationConfig struct {
 }
 
 type geminiResponse struct {
-	Candidates []geminiCandidate `json:"candidates"`
-	UsageMetadata *geminiUsage   `json:"usageMetadata"`
+	Candidates    []geminiCandidate `json:"candidates"`
+	UsageMetadata *geminiUsage      `json:"usageMetadata"`
 }
 
 type geminiCandidate struct {

--- a/internal/provider/keyrotator.go
+++ b/internal/provider/keyrotator.go
@@ -116,7 +116,7 @@ func (r *KeyRotator) activeUnlocked() []*managedKey {
 				k.state = keyStateActive
 				active = append(active, k)
 			}
-		// keyStateFailed: never re-admitted
+			// keyStateFailed: never re-admitted
 		}
 	}
 	return active

--- a/internal/resilience/degradation.go
+++ b/internal/resilience/degradation.go
@@ -7,8 +7,8 @@ import "sync"
 type DegradationMode struct {
 	Component    string `json:"component"`
 	Mode         string `json:"mode"`          // normal, degraded, emergency
-	Behavior     string `json:"behavior"`       // description of what changes
-	SafetyImpact string `json:"safety_impact"`  // what safety guarantees are affected
+	Behavior     string `json:"behavior"`      // description of what changes
+	SafetyImpact string `json:"safety_impact"` // what safety guarantees are affected
 }
 
 // DegradationManager tracks the degradation state of each component.

--- a/internal/resilience/health.go
+++ b/internal/resilience/health.go
@@ -8,7 +8,7 @@ import (
 // ComponentHealth represents the health status of a single system component.
 type ComponentHealth struct {
 	Name      string    `json:"name"`
-	Status    string    `json:"status"`    // healthy, degraded, unhealthy
+	Status    string    `json:"status"` // healthy, degraded, unhealthy
 	LastCheck time.Time `json:"last_check"`
 	Message   string    `json:"message,omitempty"`
 	SafeMode  string    `json:"safe_mode"` // what happens when this component fails

--- a/internal/resilience/retention.go
+++ b/internal/resilience/retention.go
@@ -38,7 +38,7 @@ type RetentionStats struct {
 // timestampedRecord is a generic record with a timestamp for retention
 // tracking in the in-memory store.
 type timestampedRecord struct {
-	Category  string    // "audit", "evidence", "approval"
+	Category  string // "audit", "evidence", "approval"
 	CreatedAt time.Time
 }
 

--- a/internal/resilience/retention_test.go
+++ b/internal/resilience/retention_test.go
@@ -17,7 +17,7 @@ func TestRetentionManager_Cleanup(t *testing.T) {
 
 	now := time.Now().UTC()
 	// Old records that should be cleaned up.
-	rm.AddRecord("audit", now.AddDate(0, 0, -60))    // 60 days old > 30 day policy
+	rm.AddRecord("audit", now.AddDate(0, 0, -60))     // 60 days old > 30 day policy
 	rm.AddRecord("evidence", now.AddDate(0, 0, -100)) // 100 days old > 90 day policy
 	rm.AddRecord("approval", now.AddDate(0, 0, -70))  // 70 days old > 60 day policy
 	// Recent records that should be kept.

--- a/internal/resource/model.go
+++ b/internal/resource/model.go
@@ -7,7 +7,7 @@ type Resource struct {
 	Type        ResourceType      `json:"type" yaml:"type"`
 	Provider    string            `json:"provider" yaml:"provider"`       // github, postgres, aws, shell
 	Environment string            `json:"environment" yaml:"environment"` // dev, staging, prod
-	Path        []string          `json:"path" yaml:"path"`              // hierarchical: [org, repo, branch] or [db, schema, table]
+	Path        []string          `json:"path" yaml:"path"`               // hierarchical: [org, repo, branch] or [db, schema, table]
 	Sensitivity Sensitivity       `json:"sensitivity" yaml:"sensitivity"`
 	Properties  map[string]string `json:"properties,omitempty" yaml:"properties,omitempty"`
 }

--- a/internal/storage/audit.go
+++ b/internal/storage/audit.go
@@ -7,16 +7,16 @@ import (
 )
 
 type AuditEntry struct {
-	ID          int64     `json:"id"`
-	TenantID    string    `json:"tenant_id"`
-	Model       string    `json:"model"`
-	RequestBody string    `json:"request_body"`
-	ResponseBody string   `json:"response_body"`
-	StatusCode  int       `json:"status_code"`
-	LatencyMs   int64     `json:"latency_ms"`
-	PolicyAction string   `json:"policy_action"`
-	Cached      bool      `json:"cached"`
-	CreatedAt   time.Time `json:"created_at"`
+	ID           int64     `json:"id"`
+	TenantID     string    `json:"tenant_id"`
+	Model        string    `json:"model"`
+	RequestBody  string    `json:"request_body"`
+	ResponseBody string    `json:"response_body"`
+	StatusCode   int       `json:"status_code"`
+	LatencyMs    int64     `json:"latency_ms"`
+	PolicyAction string    `json:"policy_action"`
+	Cached       bool      `json:"cached"`
+	CreatedAt    time.Time `json:"created_at"`
 }
 
 func (s *PostgresStore) MigrateAudit() error {

--- a/internal/supply/signer.go
+++ b/internal/supply/signer.go
@@ -18,7 +18,7 @@ type SignedBundle struct {
 	Signature   string    `json:"signature"`    // HMAC-SHA256 of metadata+content_hash
 	SignedAt    time.Time `json:"signed_at"`
 	SignedBy    string    `json:"signed_by"`
-	TrustTier  string    `json:"trust_tier"` // "verified", "community", "unverified"
+	TrustTier   string    `json:"trust_tier"` // "verified", "community", "unverified"
 }
 
 // Signer creates and verifies HMAC-SHA256 signatures for extension bundles.
@@ -57,7 +57,7 @@ func (s *Signer) Sign(name, version, bundleType string, content []byte) (*Signed
 		Signature:   sig,
 		SignedAt:    time.Now().UTC(),
 		SignedBy:    "aegisflow-signer",
-		TrustTier:  "verified",
+		TrustTier:   "verified",
 	}, nil
 }
 

--- a/internal/telemetry/attributes.go
+++ b/internal/telemetry/attributes.go
@@ -1,13 +1,13 @@
 package telemetry
 
 const (
-	AttrTenantID        = "aegisflow.tenant.id"
-	AttrModel           = "aegisflow.model"
-	AttrProvider        = "aegisflow.provider"
-	AttrTokensPrompt    = "aegisflow.tokens.prompt"
+	AttrTenantID         = "aegisflow.tenant.id"
+	AttrModel            = "aegisflow.model"
+	AttrProvider         = "aegisflow.provider"
+	AttrTokensPrompt     = "aegisflow.tokens.prompt"
 	AttrTokensCompletion = "aegisflow.tokens.completion"
-	AttrTokensTotal     = "aegisflow.tokens.total"
-	AttrCostUSD         = "aegisflow.cost.usd"
-	AttrPolicyViolated  = "aegisflow.policy.violated"
-	AttrStream          = "aegisflow.stream"
+	AttrTokensTotal      = "aegisflow.tokens.total"
+	AttrCostUSD          = "aegisflow.cost.usd"
+	AttrPolicyViolated   = "aegisflow.policy.violated"
+	AttrStream           = "aegisflow.stream"
 )

--- a/internal/toolpolicy/explain.go
+++ b/internal/toolpolicy/explain.go
@@ -10,7 +10,7 @@ import (
 type PolicyDecisionTrace struct {
 	Decision     string          `json:"decision"`
 	MatchedRule  *ToolRule       `json:"matched_rule,omitempty"`
-	MatchedIndex int             `json:"matched_index"`  // -1 if default
+	MatchedIndex int             `json:"matched_index"` // -1 if default
 	RulesChecked int             `json:"rules_checked"`
 	DefaultUsed  bool            `json:"default_used"`
 	CheckTrace   []RuleCheckStep `json:"check_trace"`

--- a/internal/usage/tracker.go
+++ b/internal/usage/tracker.go
@@ -5,12 +5,12 @@ import (
 )
 
 var costPerMillionTokens = map[string]float64{
-	"gpt-4o":                    5.0,
-	"gpt-4o-mini":               0.15,
-	"claude-sonnet-4-20250514":  3.0,
-	"llama3":                    0.0,
-	"mock":                      0.0,
-	"mock-fast":                 0.0,
+	"gpt-4o":                   5.0,
+	"gpt-4o-mini":              0.15,
+	"claude-sonnet-4-20250514": 3.0,
+	"llama3":                   0.0,
+	"mock":                     0.0,
+	"mock-fast":                0.0,
 }
 
 type Tracker struct {

--- a/tests/integration/runtime_integration_test.go
+++ b/tests/integration/runtime_integration_test.go
@@ -20,9 +20,12 @@ type testNotifier struct {
 	denyCalled    int
 }
 
-func (n *testNotifier) NotifyReview(item *approval.ApprovalItem) error   { n.reviewCalled++; return nil }
-func (n *testNotifier) NotifyApproved(item *approval.ApprovalItem) error { n.approveCalled++; return nil }
-func (n *testNotifier) NotifyDenied(item *approval.ApprovalItem) error   { n.denyCalled++; return nil }
+func (n *testNotifier) NotifyReview(item *approval.ApprovalItem) error { n.reviewCalled++; return nil }
+func (n *testNotifier) NotifyApproved(item *approval.ApprovalItem) error {
+	n.approveCalled++
+	return nil
+}
+func (n *testNotifier) NotifyDenied(item *approval.ApprovalItem) error { n.denyCalled++; return nil }
 
 func TestApprovalNotifierIntegrationE2E(t *testing.T) {
 	aq := approval.NewQueue(100)


### PR DESCRIPTION
## What changed

- Let the server use `AEGISFLOW_CONFIG` as the default config path, so Docker Compose and Kubernetes-mounted configs are honored without extra flags.
- Updated the container entrypoint and Helm deployment wiring so mounted config files and custom service ports work as expected.
- Added validation for empty, duplicate, and invalid tenant API key entries.
- Added a Docker ignore file to keep local binaries, run artifacts, media, and notes out of build contexts.
- Added a `fmt-check` target and CI format check, then normalized existing Go formatting.

## Why

The deployment manifests were setting or mounting config files that the binary could ignore by default, which could confuse users running the Docker or Helm paths. Tenant API key validation also needed to fail earlier for ambiguous or unusable auth configuration. The Docker build context was much larger than necessary because local artifacts were not excluded.

## Validation

- `make fmt-check`
- `go test ./... -count=1`
- `go build ./...`
- `go test ./... -race -count=1`
- `docker build -t aegisflow:local-check .`
- `docker run --rm aegisflow:local-check --version`
- `docker run --rm -e AEGISFLOW_CONFIG=/missing/aegisflow.yaml aegisflow:local-check`