### PR TITLE
feat: add --version/-v flags with "aegisflow <version>" output

### DIFF
--- a/cmd/aegisflow/main.go
+++ b/cmd/aegisflow/main.go
@@ -77,11 +77,12 @@ func (a *notifierAdapter) NotifyDenied(item *approval.ApprovalItem) error {
 func main() {
 	configPath := flag.String("config", defaultConfigPath(), "path to config file")
 	showVersion := flag.Bool("version", false, "print aegisflow version")
+	flag.BoolVar(showVersion, "v", false, "print aegisflow version (shorthand)")
 	flag.Parse()
 
 	if *showVersion {
-		fmt.Println(version)
-		return
+		fmt.Println("aegisflow", version)
+		os.Exit(0)
 	}
 
 	loadEnvFile(".env")

--- a/cmd/aegisflow/main_test.go
+++ b/cmd/aegisflow/main_test.go
@@ -1,6 +1,11 @@
 package main
 
-import "testing"
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"testing"
+)
 
 func TestDefaultConfigPathUsesFallback(t *testing.T) {
 	t.Setenv("AEGISFLOW_CONFIG", "")
@@ -16,4 +21,58 @@ func TestDefaultConfigPathUsesEnvironment(t *testing.T) {
 	if got := defaultConfigPath(); got != "/etc/aegisflow/aegisflow.yaml" {
 		t.Fatalf("defaultConfigPath() = %q", got)
 	}
+}
+
+func TestVersionFlagLong(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=^TestHelperVersionLong$")
+	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
+
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+
+	err := cmd.Run()
+	if err != nil {
+		t.Fatalf("helper process failed: %v", err)
+	}
+
+	expected := "aegisflow " + version + "\n"
+	if got := stdout.String(); got != expected {
+		t.Fatalf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestHelperVersionLong(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	os.Args = []string{"aegisflow", "-version"}
+	main()
+	os.Exit(0)
+}
+
+func TestVersionFlagShort(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=^TestHelperVersionShort$")
+	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
+
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+
+	err := cmd.Run()
+	if err != nil {
+		t.Fatalf("helper process failed: %v", err)
+	}
+
+	expected := "aegisflow " + version + "\n"
+	if got := stdout.String(); got != expected {
+		t.Fatalf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestHelperVersionShort(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	os.Args = []string{"aegisflow", "-v"}
+	main()
+	os.Exit(0)
 }


### PR DESCRIPTION
- Add -v shorthand for --version flag
- Output format: "aegisflow v0.7.0"
- Add version format tests

## What does this PR do?

<!-- Describe the change in 1-3 sentences -->

## Related Issue

<!-- Link to the GitHub issue this PR addresses -->
Closes #76 

## Type of Change

- [ ] New provider adapter
- [ ] New policy filter
- [ ] Bug fix
- [x] Enhancement
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing code style
- [x] I have added tests for my changes
- [x] All tests pass (`make test`)
- [x] I have updated documentation if needed
