### PR TITLE
Add docs-writer policy pack

### DIFF
--- a/starter-kit/README.md
+++ b/starter-kit/README.md
@@ -32,12 +32,13 @@ This builds AegisFlow, copies your chosen policy pack, starts the service, and v
 
 ### Step 2: Pick a policy pack
 
-Four policy packs are included in `policies/`. Copy one to configure your governance posture:
+Five policy packs are included in `policies/`. Copy one to configure your governance posture:
 
 | Pack | Use when... |
 |------|------------|
 | `readonly.yaml` | Agent should only read. No writes, no deletes. Audits and investigations. |
 | `pr-writer.yaml` | Agent writes code and opens PRs. Destructive ops blocked, writes reviewed. |
+| `docs-writer.yaml` | Agent reads code but only writes docs. Source-code writes blocked. See `docs-writer-tuning-notes.md`. |
 | `infra-review.yaml` | Agent does infrastructure work. Everything destructive needs human approval. |
 | `sql-explorer.yaml` | BI/data agent explores a database read-first. SELECT allowed, writes reviewed, destructive SQL blocked. See `sql-explorer-tuning-notes.md`. |
 

--- a/starter-kit/install.sh
+++ b/starter-kit/install.sh
@@ -60,18 +60,20 @@ echo ""
 echo -e "${BOLD}Choose a policy pack:${NC}"
 echo "  1) readonly    -- Agent can only read. No writes, no deletes."
 echo "  2) pr-writer   -- Agent reads + writes PRs. Destructive ops blocked."
-echo "  3) infra-review -- Agent does infra work. Destructive ops need review."
+echo "  3) docs-writer -- Agent reads code but only writes docs. Source writes blocked."
+echo "  4) infra-review -- Agent does infra work. Destructive ops need review."
 echo ""
 
 POLICY_CHOICE="${AEGISFLOW_POLICY:-}"
 if [ -z "$POLICY_CHOICE" ]; then
-    read -r -p "Pick a policy [1/2/3] (default: 2): " POLICY_CHOICE
+    read -r -p "Pick a policy [1/2/3/4] (default: 2): " POLICY_CHOICE
     POLICY_CHOICE="${POLICY_CHOICE:-2}"
 fi
 
 case "$POLICY_CHOICE" in
     1|readonly)    POLICY_FILE="readonly.yaml";     POLICY_NAME="readonly" ;;
-    3|infra-review) POLICY_FILE="infra-review.yaml"; POLICY_NAME="infra-review" ;;
+    3|docs-writer) POLICY_FILE="docs-writer.yaml"; POLICY_NAME="docs-writer" ;;
+    4|infra-review) POLICY_FILE="infra-review.yaml"; POLICY_NAME="infra-review" ;;
     *)             POLICY_FILE="pr-writer.yaml";     POLICY_NAME="pr-writer" ;;
 esac
 

--- a/starter-kit/policies/docs-writer-tuning-notes.md
+++ b/starter-kit/policies/docs-writer-tuning-notes.md
@@ -1,0 +1,69 @@
+# Docs Writer Policy Pack - Tuning Notes
+
+## Philosophy: understand code, write docs
+
+`docs-writer.yaml` is for agents that improve documentation but should not
+modify source code. The agent can inspect the whole repository so it can write
+accurate docs, but its write surface stays limited to Markdown and common docs
+locations.
+
+Use this pack for README rewrites, API docs, changelog drafts, contributor
+guides, troubleshooting docs, and docs-site updates.
+
+Do not use this pack for feature work, migrations, infra changes, or production
+operations. Use `pr-writer.yaml`, `infra-review.yaml`, or `sql-explorer.yaml`
+instead.
+
+## What's allowed
+
+| Area | Allowed | Why |
+|------|---------|-----|
+| GitHub | `list_*`, `get_*`, `search_*` | The agent needs context before editing docs. |
+| GitHub | `create_branch`, `create_commit` | Docs work still needs normal branch/commit flow. |
+| Shell | `ls`, `pwd`, `grep`, `find`, `head`, `tail`, `wc`, `diff`, `less`, safe `cat` | Reading and comparing files is core docs work. |
+| Shell | read-only `git` commands, `git checkout`, `git switch`, `git fetch`, `git add`, `git commit`, `git stash` | Local git workflow for docs branches. |
+| Shell | test/build/lint commands | Docs changes often need link, formatting, or site-build checks. |
+| SQL | `SELECT` | Read-only inspection is okay when documenting data behavior. |
+| HTTP | `GET`, `HEAD` | Fetching public docs or checking links is okay. |
+
+## What's reviewed
+
+| Area | Reviewed | Why |
+|------|----------|-----|
+| GitHub | `create_pull_request` | The PR is the human review checkpoint. |
+| GitHub | docs-file `create_or_update_file` | Direct GitHub writes should stay visible to a reviewer. |
+| Shell | `git push`, `git reset --hard` | Leaves local-only safety or changes local state sharply. |
+| Shell | package install and generic build tools | Can run arbitrary project scripts. |
+| Shell | `docker`, `kubectl`, `terraform` | Usually outside docs-only scope. |
+| SQL | `INSERT`, `UPDATE` | Mutates data, even if a docs task asks for examples. |
+| HTTP | `POST`, `PUT`, `PATCH` | Mutates remote systems. |
+
+## What's blocked
+
+| Area | Blocked | Why |
+|------|---------|-----|
+| GitHub | repo deletion, force push, deleting `main`/`master`, inviting collaborators | Administrative or destructive. |
+| GitHub | direct writes to common source-code extensions | Docs agents should open docs PRs, not patch product code. |
+| Shell | direct edits to common source-code extensions | Keeps the agent inside docs-only work. |
+| Shell | destructive commands and protected paths | Same safety baseline as `pr-writer`. |
+| SQL | `DELETE`, `DROP`, `TRUNCATE`, `GRANT`, `REVOKE` | Never part of documentation authoring. |
+| HTTP | `DELETE` | Destructive remote mutation. |
+| Global | delete capability | Backstop for unclassified tools. |
+
+## Why source-code writes are blocked
+
+A docs agent often needs to read implementation files to understand behavior.
+That is different from being allowed to modify them. If the agent discovers a
+real code bug while documenting, it should mention it in the PR or open a
+follow-up issue, not silently mix code changes into a docs PR.
+
+## Customizing for your team
+
+- Add extra docs paths if your repo uses `handbook/`, `website/docs/`, or
+  `content/`.
+- Downgrade docs-file GitHub writes from `review` to `allow` if your team wants
+  fully automated docs branches.
+- If generated docs live beside source files, add the exact generated path
+  before the broad source-code blocks.
+- If your docs build requires a specific command, add an explicit `allow` rule
+  above the generic package-manager review rules.

--- a/starter-kit/policies/docs-writer.yaml
+++ b/starter-kit/policies/docs-writer.yaml
@@ -1,0 +1,204 @@
+# AegisFlow Policy Pack: Docs Writer
+#
+# Use this when an agent is allowed to improve documentation but should not
+# modify product source code. It can read the repo, inspect implementation
+# details, edit Markdown/docs files, run docs checks, and open a reviewed PR.
+#
+# Philosophy: "read broadly, write narrowly."
+#   - Reading anything in the repo is free, except secrets.
+#   - Markdown and docs locations are the only intended write surface.
+#   - Opening a PR is a review checkpoint.
+#   - Source-code writes, destructive shell, SQL writes, and dangerous remote
+#     mutations are blocked or reviewed.
+#
+# When NOT to use this pack:
+#   - Feature/code work              -> use pr-writer.yaml
+#   - Infra/Terraform/k8s work       -> use infra-review.yaml
+#   - Database exploration           -> use sql-explorer.yaml
+#   - Audits / read-only assistants  -> use readonly.yaml
+
+tool_policies:
+  enabled: true
+  default_decision: "review"
+  rules:
+    # GitHub: reads are always free.
+    - { protocol: "git", tool: "github.list_*",   decision: "allow" }
+    - { protocol: "git", tool: "github.get_*",    decision: "allow" }
+    - { protocol: "git", tool: "github.search_*", decision: "allow" }
+    - { protocol: "mcp", tool: "github.list_*",   decision: "allow" }
+    - { protocol: "mcp", tool: "github.get_*",    decision: "allow" }
+    - { protocol: "mcp", tool: "github.search_*", decision: "allow" }
+
+    # GitHub: branch/commit flow is allowed for docs work.
+    - { protocol: "git", tool: "github.create_branch", decision: "allow" }
+    - { protocol: "mcp", tool: "github.create_branch", decision: "allow" }
+    - { protocol: "git", tool: "github.create_commit", decision: "allow" }
+    - { protocol: "mcp", tool: "github.create_commit", decision: "allow" }
+
+    # GitHub: direct writes are reviewed for docs paths and blocked for source.
+    - { protocol: "git", tool: "github.create_or_update_file", target: "*.md",       decision: "review" }
+    - { protocol: "git", tool: "github.create_or_update_file", target: "*.mdx",      decision: "review" }
+    - { protocol: "git", tool: "github.create_or_update_file", target: "README*",    decision: "review" }
+    - { protocol: "git", tool: "github.create_or_update_file", target: "CHANGELOG*", decision: "review" }
+    - { protocol: "git", tool: "github.create_or_update_file", target: "docs/**",    decision: "review" }
+    - { protocol: "mcp", tool: "github.create_or_update_file", target: "*.md",       decision: "review" }
+    - { protocol: "mcp", tool: "github.create_or_update_file", target: "*.mdx",      decision: "review" }
+    - { protocol: "mcp", tool: "github.create_or_update_file", target: "README*",    decision: "review" }
+    - { protocol: "mcp", tool: "github.create_or_update_file", target: "CHANGELOG*", decision: "review" }
+    - { protocol: "mcp", tool: "github.create_or_update_file", target: "docs/**",    decision: "review" }
+    - { protocol: "git", tool: "github.create_or_update_file", target: "*.go",    decision: "block" }
+    - { protocol: "git", tool: "github.create_or_update_file", target: "*.py",    decision: "block" }
+    - { protocol: "git", tool: "github.create_or_update_file", target: "*.js",    decision: "block" }
+    - { protocol: "git", tool: "github.create_or_update_file", target: "*.jsx",   decision: "block" }
+    - { protocol: "git", tool: "github.create_or_update_file", target: "*.ts",    decision: "block" }
+    - { protocol: "git", tool: "github.create_or_update_file", target: "*.tsx",   decision: "block" }
+    - { protocol: "git", tool: "github.create_or_update_file", target: "*.rs",    decision: "block" }
+    - { protocol: "git", tool: "github.create_or_update_file", target: "*.java",  decision: "block" }
+    - { protocol: "git", tool: "github.create_or_update_file", target: "*.kt",    decision: "block" }
+    - { protocol: "git", tool: "github.create_or_update_file", target: "*.swift", decision: "block" }
+    - { protocol: "mcp", tool: "github.create_or_update_file", target: "*.go",    decision: "block" }
+    - { protocol: "mcp", tool: "github.create_or_update_file", target: "*.py",    decision: "block" }
+    - { protocol: "mcp", tool: "github.create_or_update_file", target: "*.js",    decision: "block" }
+    - { protocol: "mcp", tool: "github.create_or_update_file", target: "*.jsx",   decision: "block" }
+    - { protocol: "mcp", tool: "github.create_or_update_file", target: "*.ts",    decision: "block" }
+    - { protocol: "mcp", tool: "github.create_or_update_file", target: "*.tsx",   decision: "block" }
+    - { protocol: "mcp", tool: "github.create_or_update_file", target: "*.rs",    decision: "block" }
+    - { protocol: "mcp", tool: "github.create_or_update_file", target: "*.java",  decision: "block" }
+    - { protocol: "mcp", tool: "github.create_or_update_file", target: "*.kt",    decision: "block" }
+    - { protocol: "mcp", tool: "github.create_or_update_file", target: "*.swift", decision: "block" }
+
+    # GitHub: opening a PR is the review point.
+    - { protocol: "git", tool: "github.create_pull_request", decision: "review" }
+    - { protocol: "mcp", tool: "github.create_pull_request", decision: "review" }
+
+    # GitHub: risky and destructive ops.
+    - { protocol: "git", tool: "github.merge_pull_request",       decision: "review" }
+    - { protocol: "mcp", tool: "github.merge_pull_request",       decision: "review" }
+    - { protocol: "git", tool: "github.create_deployment",        decision: "review" }
+    - { protocol: "mcp", tool: "github.create_deployment",        decision: "review" }
+    - { protocol: "git", tool: "github.update_branch_protection", decision: "review" }
+    - { protocol: "git", tool: "github.delete_repo",              decision: "block" }
+    - { protocol: "mcp", tool: "github.delete_repo",              decision: "block" }
+    - { protocol: "git", tool: "github.delete_branch", target: "main",   decision: "block" }
+    - { protocol: "git", tool: "github.delete_branch", target: "master", decision: "block" }
+    - { protocol: "mcp", tool: "github.delete_branch", target: "main",   decision: "block" }
+    - { protocol: "mcp", tool: "github.delete_branch", target: "master", decision: "block" }
+    - { protocol: "git", tool: "github.force_push",          decision: "block" }
+    - { protocol: "git", tool: "github.invite_collaborator", decision: "block" }
+
+    # Shell: reads and everyday navigation.
+    - { protocol: "shell", tool: "shell.ls",    decision: "allow" }
+    - { protocol: "shell", tool: "shell.pwd",   decision: "allow" }
+    - { protocol: "shell", tool: "shell.echo",  decision: "allow" }
+    - { protocol: "shell", tool: "shell.grep",  decision: "allow" }
+    - { protocol: "shell", tool: "shell.find",  decision: "allow" }
+    - { protocol: "shell", tool: "shell.head",  decision: "allow" }
+    - { protocol: "shell", tool: "shell.tail",  decision: "allow" }
+    - { protocol: "shell", tool: "shell.wc",    decision: "allow" }
+    - { protocol: "shell", tool: "shell.diff",  decision: "allow" }
+    - { protocol: "shell", tool: "shell.less",  decision: "allow" }
+
+    # cat is allow-by-default, but never let it read secrets.
+    - { protocol: "shell", tool: "shell.cat", target: ".env",            decision: "block" }
+    - { protocol: "shell", tool: "shell.cat", target: "*.env",           decision: "block" }
+    - { protocol: "shell", tool: "shell.cat", target: "/etc/shadow",     decision: "block" }
+    - { protocol: "shell", tool: "shell.cat", target: "/etc/passwd",     decision: "block" }
+    - { protocol: "shell", tool: "shell.cat", target: "**/.ssh/*",       decision: "block" }
+    - { protocol: "shell", tool: "shell.cat", target: "**/credentials*", decision: "block" }
+    - { protocol: "shell", tool: "shell.cat", decision: "allow" }
+
+    # Shell: direct docs edits are reviewed; source-code edits are blocked.
+    - { protocol: "shell", tool: "shell.*", target: "*.md",       decision: "review" }
+    - { protocol: "shell", tool: "shell.*", target: "*.mdx",      decision: "review" }
+    - { protocol: "shell", tool: "shell.*", target: "README*",    decision: "review" }
+    - { protocol: "shell", tool: "shell.*", target: "CHANGELOG*", decision: "review" }
+    - { protocol: "shell", tool: "shell.*", target: "docs/**",    decision: "review" }
+    - { protocol: "shell", tool: "shell.*", target: "*.go",    decision: "block" }
+    - { protocol: "shell", tool: "shell.*", target: "*.py",    decision: "block" }
+    - { protocol: "shell", tool: "shell.*", target: "*.js",    decision: "block" }
+    - { protocol: "shell", tool: "shell.*", target: "*.jsx",   decision: "block" }
+    - { protocol: "shell", tool: "shell.*", target: "*.ts",    decision: "block" }
+    - { protocol: "shell", tool: "shell.*", target: "*.tsx",   decision: "block" }
+    - { protocol: "shell", tool: "shell.*", target: "*.rs",    decision: "block" }
+    - { protocol: "shell", tool: "shell.*", target: "*.java",  decision: "block" }
+    - { protocol: "shell", tool: "shell.*", target: "*.kt",    decision: "block" }
+    - { protocol: "shell", tool: "shell.*", target: "*.swift", decision: "block" }
+
+    # Shell: git read/local workflow.
+    - { protocol: "shell", tool: "shell.git", target: "git status*",       decision: "allow" }
+    - { protocol: "shell", tool: "shell.git", target: "git log*",          decision: "allow" }
+    - { protocol: "shell", tool: "shell.git", target: "git diff*",         decision: "allow" }
+    - { protocol: "shell", tool: "shell.git", target: "git show*",         decision: "allow" }
+    - { protocol: "shell", tool: "shell.git", target: "git blame*",        decision: "allow" }
+    - { protocol: "shell", tool: "shell.git", target: "git branch*",       decision: "allow" }
+    - { protocol: "shell", tool: "shell.git", target: "git checkout*",     decision: "allow" }
+    - { protocol: "shell", tool: "shell.git", target: "git switch*",       decision: "allow" }
+    - { protocol: "shell", tool: "shell.git", target: "git fetch*",        decision: "allow" }
+    - { protocol: "shell", tool: "shell.git", target: "git add*",          decision: "allow" }
+    - { protocol: "shell", tool: "shell.git", target: "git commit*",       decision: "allow" }
+    - { protocol: "shell", tool: "shell.git", target: "git stash*",        decision: "allow" }
+    - { protocol: "shell", tool: "shell.git", target: "git push --force*", decision: "block" }
+    - { protocol: "shell", tool: "shell.git", target: "git push -f*",      decision: "block" }
+    - { protocol: "shell", tool: "shell.git", target: "git push*",         decision: "review" }
+    - { protocol: "shell", tool: "shell.git", target: "git reset --hard*", decision: "review" }
+    - { protocol: "shell", tool: "shell.git", decision: "allow" }
+
+    # Shell: docs validation and site builds.
+    - { protocol: "shell", tool: "shell.pytest", decision: "allow" }
+    - { protocol: "shell", tool: "shell.go",     decision: "allow" }
+    - { protocol: "shell", tool: "shell.cargo", target: "cargo test*",      decision: "allow" }
+    - { protocol: "shell", tool: "shell.cargo", target: "cargo build*",     decision: "allow" }
+    - { protocol: "shell", tool: "shell.cargo", target: "cargo check*",     decision: "allow" }
+    - { protocol: "shell", tool: "shell.cargo", decision: "review" }
+    - { protocol: "shell", tool: "shell.npm", target: "npm test*",          decision: "allow" }
+    - { protocol: "shell", tool: "shell.npm", target: "npm run test*",      decision: "allow" }
+    - { protocol: "shell", tool: "shell.npm", target: "npm run build*",     decision: "allow" }
+    - { protocol: "shell", tool: "shell.npm", target: "npm ci*",            decision: "allow" }
+    - { protocol: "shell", tool: "shell.npm", target: "npm install*",       decision: "review" }
+    - { protocol: "shell", tool: "shell.npm", decision: "review" }
+    - { protocol: "shell", tool: "shell.make", target: "make test*",        decision: "allow" }
+    - { protocol: "shell", tool: "shell.make", target: "make build*",       decision: "allow" }
+    - { protocol: "shell", tool: "shell.make", target: "make lint*",        decision: "allow" }
+    - { protocol: "shell", tool: "shell.make", decision: "review" }
+
+    # Shell: infra tools are outside docs-only scope.
+    - { protocol: "shell", tool: "shell.kubectl",   decision: "review" }
+    - { protocol: "shell", tool: "shell.terraform", decision: "review" }
+    - { protocol: "shell", tool: "shell.docker",    decision: "review" }
+
+    # Shell: protected paths and destructive commands.
+    - { protocol: "shell", tool: "shell.*", target: "/etc/*",          decision: "block" }
+    - { protocol: "shell", tool: "shell.*", target: "**/.ssh/*",       decision: "block" }
+    - { protocol: "shell", tool: "shell.*", target: "**/.env",         decision: "block" }
+    - { protocol: "shell", tool: "shell.*", target: "**/credentials*", decision: "block" }
+    - { protocol: "shell", tool: "shell.rm",       decision: "block" }
+    - { protocol: "shell", tool: "shell.dd",       decision: "block" }
+    - { protocol: "shell", tool: "shell.mkfs",     decision: "block" }
+    - { protocol: "shell", tool: "shell.chmod",    decision: "block" }
+    - { protocol: "shell", tool: "shell.shutdown", decision: "block" }
+    - { protocol: "shell", tool: "shell.reboot",   decision: "block" }
+    - { protocol: "shell", tool: "shell.killall",  decision: "block" }
+    - { protocol: "shell", tool: "shell.env",      decision: "block" }
+    - { protocol: "shell", tool: "shell.printenv", decision: "block" }
+
+    # SQL: docs agents may inspect, not mutate.
+    - { protocol: "sql", tool: "sql.select",   decision: "allow" }
+    - { protocol: "sql", tool: "sql.insert",   decision: "review" }
+    - { protocol: "sql", tool: "sql.update",   decision: "review" }
+    - { protocol: "sql", tool: "sql.delete",   decision: "block" }
+    - { protocol: "sql", tool: "sql.drop_*",   decision: "block" }
+    - { protocol: "sql", tool: "sql.truncate", decision: "block" }
+    - { protocol: "sql", tool: "sql.grant",    decision: "block" }
+    - { protocol: "sql", tool: "sql.revoke",   decision: "block" }
+
+    # HTTP: link checking is fine; mutations are not.
+    - { protocol: "http", tool: "http.get",    decision: "allow" }
+    - { protocol: "http", tool: "http.head",   decision: "allow" }
+    - { protocol: "http", tool: "http.post",   decision: "review" }
+    - { protocol: "http", tool: "http.put",    decision: "review" }
+    - { protocol: "http", tool: "http.patch",  decision: "review" }
+    - { protocol: "http", tool: "http.delete", decision: "block" }
+
+    # Global backstop: anything tagged as delete is blocked.
+    - { protocol: "*", tool: "*", capability: "delete", decision: "block" }
+


### PR DESCRIPTION
## Summary
- add a docs-writer starter-kit policy pack based on the existing pr-writer structure
- allow Markdown/docs/config edits while blocking code changes such as .go files
- add tuning notes and expose the pack in the starter-kit README and installer

Closes #80.

## Validation
- Parsed starter-kit/policies/docs-writer.yaml successfully with PyYAML
- git diff --check passed
- go test ./internal/toolpolicy was not run locally because Go is not installed in this environment