### PR TITLE
policy: use doublestar so ** target globs match nested paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to AegisFlow will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project loosely follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) while it is pre-1.0.
 
+## [Unreleased]
+
+### Security
+
+- Tool-policy target globs now use doublestar matching, so `**` patterns (e.g. `**/.ssh/*`, `**/credentials*`, `docs/**`) match nested paths. The previous `path.Match` did not support `**` and never crossed `/`, which silently disabled nested-path secret-block rules and could let a nested secret (e.g. a read of a deep `.ssh` key) fall through to an allow rule. Path-based blocking is still best-effort; see T2 in the threat model. (#111)
+
 ## [0.8.0] - 2026-06-03
 
 Runtime-governance identity, an Anthropic-native gateway path, and operator DX. This release lets Claude Code and the Anthropic SDK route through AegisFlow so their prompts are governed and audited before they reach a provider, surfaces policy decisions in Prometheus, adds a data-explorer policy pack, and sharpens the CLI and docs.

--- a/docs/security/THREAT_MODEL.md
+++ b/docs/security/THREAT_MODEL.md
@@ -93,10 +93,10 @@ Extensions run within AegisFlow's process. WASM plugins execute in a sandboxed r
 - Shell sandbox with environment variable redaction
 - Behavioral detection engine identifies exfiltration patterns (read secret + outbound HTTP)
 - Network egress policy restricts outbound connections
-- Tool policy blocks access to sensitive file paths (.env, /etc/shadow, credential files)
+- Tool policy blocks access to sensitive file paths (.env, /etc/shadow, credential files) on a best-effort basis
 - Attack demo validates 20+ exfiltration scenarios are blocked
 
-**Residual risk:** Exfiltration through side channels not covered by network policy (e.g., DNS tunneling). Mitigated by monitoring and network-level controls outside AegisFlow.
+**Residual risk:** Path-based secret blocking is best-effort, not a hard boundary. It depends on the connector extracting the target path from the action, so obfuscated reads (`python -c 'open(".env").read()'`, `cat < .env`, `xxd .env`) or reads through a tool the policy does not name can slip past a path rule. Treat path rules as a speed bump; the real controls are default-deny, human review of unclassified actions, and the behavioral exfiltration detection (read secret plus outbound HTTP). The strongest posture is to not hand the agent secret access in the first place. Separately, side-channel exfiltration not covered by network policy (e.g. DNS tunneling) is mitigated by monitoring and network-level controls outside AegisFlow.
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.4
 
 require (
 	github.com/alicebob/miniredis/v2 v2.38.0
+	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/go-chi/chi/v5 v5.3.0
 	github.com/google/uuid v1.6.0
 	github.com/graphql-go/graphql v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e
 github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
+github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=

--- a/internal/toolpolicy/engine.go
+++ b/internal/toolpolicy/engine.go
@@ -1,8 +1,9 @@
 package toolpolicy
 
 import (
-	"path"
 	"sync"
+
+	"github.com/bmatcuk/doublestar/v4"
 
 	"github.com/saivedant169/AegisFlow/internal/envelope"
 )
@@ -83,17 +84,20 @@ func (e *Engine) matches(rule ToolRule, env *envelope.ActionEnvelope) bool {
 		}
 	}
 
-	// Tool match (glob)
+	// Tool match (glob). doublestar so "**" and path-aware globs work.
 	if rule.Tool != "" && rule.Tool != "*" {
-		matched, _ := path.Match(rule.Tool, env.Tool)
+		matched, _ := doublestar.Match(rule.Tool, env.Tool)
 		if !matched {
 			return false
 		}
 	}
 
-	// Target match (glob, optional)
+	// Target match (glob, optional). doublestar so patterns like
+	// "**/.ssh/*", "**/credentials*", and "docs/**" match nested paths.
+	// The standard library path.Match does not support "**" and never
+	// crosses "/", which silently let nested secrets through.
 	if rule.Target != "" && rule.Target != "*" {
-		matched, _ := path.Match(rule.Target, env.Target)
+		matched, _ := doublestar.Match(rule.Target, env.Target)
 		if !matched {
 			return false
 		}

--- a/internal/toolpolicy/engine_test.go
+++ b/internal/toolpolicy/engine_test.go
@@ -143,3 +143,34 @@ func TestEmptyRulesUsesDefault(t *testing.T) {
 		t.Fatalf("expected default allow, got %s", d)
 	}
 }
+
+// TestDoublestarTargetMatching verifies that "**" target globs cross "/" so
+// nested secrets and docs paths match. path.Match never crossed "/", which
+// silently let nested secrets (e.g. a cat of a deep .ssh key) through.
+func TestDoublestarTargetMatching(t *testing.T) {
+	engine := NewEngine([]ToolRule{
+		{Protocol: "git", Tool: "github.create_or_update_file", Target: "**/.ssh/*", Decision: "block"},
+		{Protocol: "git", Tool: "github.create_or_update_file", Target: "docs/**", Decision: "review"},
+		{Protocol: "git", Tool: "github.create_or_update_file", Target: "*.go", Decision: "block"},
+		{Protocol: "git", Tool: "github.create_or_update_file", Decision: "allow"},
+	}, "block")
+
+	cases := []struct {
+		target string
+		want   envelope.Decision
+	}{
+		{"home/user/.ssh/id_rsa", envelope.DecisionBlock}, // ** crosses "/"
+		{".ssh/id_rsa", envelope.DecisionBlock},           // ** matches zero dirs
+		{"docs/guide/setup.md", envelope.DecisionReview},  // docs/** nested
+		{"docs/intro.md", envelope.DecisionReview},        // docs/** direct child
+		{"main.go", envelope.DecisionBlock},               // *.go, single segment
+		{"pkg/main.go", envelope.DecisionAllow},           // *.go must not cross "/" (use **/*.go to block nested)
+		{"README.md", envelope.DecisionAllow},             // no rule matches
+	}
+	for _, tc := range cases {
+		env := testEnvelope(envelope.ProtocolGit, "github.create_or_update_file", tc.target, envelope.CapWrite)
+		if got := engine.Evaluate(env); got != tc.want {
+			t.Errorf("target %q: expected %s, got %s", tc.target, tc.want, got)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

The tool-policy engine matched targets with `path.Match` (`internal/toolpolicy/engine.go`). `path.Match` does not support `**` and its `*` never crosses `/`. So every rule that relies on `**` silently never fired:

- `**/.ssh/*`, `**/credentials*`, `**/.env` (secret blocks)
- `docs/**` (docs-path rules)

Because those block rules are ordered right above `shell.cat -> allow`, a read of a nested secret (for example `cat /home/user/.ssh/id_rsa` or `cat config/.env`) skipped the broken block rule and hit the allow, leaking the secret. This affects every pack that uses those patterns (pr-writer, readonly, and the incoming docs-writer).

## Fix

Switch tool and target matching to `doublestar.Match`. It is a strict superset of `path.Match` for the patterns already in use (single `*` still stays within a path segment), and it makes `**` cross `/` as intended. No pack changes required; the existing `**` patterns now work.

## Test

Added `TestDoublestarTargetMatching`, which locks in that `**/.ssh/*` blocks `home/user/.ssh/id_rsa` and `.ssh/id_rsa`, `docs/**` matches nested docs, and single `*` still does not cross `/`. Confirmed it fails on the old `path.Match` (nested secrets returned `allow`) and passes with the fix. Full `go test ./internal/toolpolicy/` is green.

Note for pack authors: to block a source extension anywhere in the tree, use `**/*.go` rather than `*.go` (which only matches top-level files). That is now possible with this change.