### PR TITLE
Bump go directive to 1.26.5 to clear GO-2026-5856

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine
+FROM golang:1.26.5-alpine
 
 RUN apk add --no-cache git ca-certificates build-base && \
     go install github.com/air-verse/air@latest

--- a/Dockerfile.operator
+++ b/Dockerfile.operator
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine AS builder
 RUN apk add --no-cache git ca-certificates
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ docker run --rm -p 8080:8080 -p 8081:8081 \
   saivedant169/aegisflow:v0.8.0
 ```
 
-Building from source still works (`make build`, Go 1.26.4+) if you prefer.
+Building from source still works (`make build`, Go 1.26.5+) if you prefer.
 
 ---
 
@@ -214,7 +214,7 @@ Putting nginx or Caddy in front for TLS, SSE buffering, and admin-port isolation
 ### Option 2: Run locally
 
 ```bash
-# Install Go 1.26.4+
+# Install Go 1.26.5+
 brew install go
 
 # Clone and build

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Go 1.26.4+ (for building from source)
+- Go 1.26.5+ (for building from source)
 - Docker and Docker Compose (for containerized deployment)
 
 ## Quick Start

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/saivedant169/AegisFlow
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/alicebob/miniredis/v2 v2.38.0

--- a/starter-kit/install-pr-writer.sh
+++ b/starter-kit/install-pr-writer.sh
@@ -36,7 +36,7 @@ echo "==========================================="
 hdr "1) Checking prerequisites"
 
 if ! command -v go >/dev/null 2>&1; then
-    fail "Go not found (need 1.26.4+)"
+    fail "Go not found (need 1.26.5+)"
     cleanup_fail
 fi
 GO_VER=$(go version | awk '{print $3}' | sed 's/go//')
@@ -47,7 +47,7 @@ GO_PATCH="${GO_PATCH:-0}"
 if [ "$GO_MAJOR" -lt 1 ] || \
    { [ "$GO_MAJOR" -eq 1 ] && [ "$GO_MINOR" -lt 26 ]; } || \
    { [ "$GO_MAJOR" -eq 1 ] && [ "$GO_MINOR" -eq 26 ] && [ "$GO_PATCH" -lt 4 ]; }; then
-    fail "Go $GO_VER too old (need 1.26.4+)"
+    fail "Go $GO_VER too old (need 1.26.5+)"
     cleanup_fail
 fi
 pass "Go $GO_VER"

--- a/starter-kit/install.sh
+++ b/starter-kit/install.sh
@@ -44,7 +44,7 @@ fi
 
 if [ "$HAS_DOCKER" = false ] && [ "$HAS_GO" = false ]; then
     echo ""
-    echo -e "${RED}Error: Need either Docker or Go 1.26.4+ installed.${NC}"
+    echo -e "${RED}Error: Need either Docker or Go 1.26.5+ installed.${NC}"
     echo "  Install Docker: https://docs.docker.com/get-docker/"
     echo "  Install Go:     https://go.dev/dl/"
     exit 1


### PR DESCRIPTION
CI is failing on the `govulncheck` step of the test job:

```
Vulnerability #1: GO-2026-5856
  Standard library
    Found in: crypto/tls@go1.26.4
    Fixed in: crypto/tls@go1.26.5
```

This is a `crypto/tls` vulnerability in the Go standard library, not a dependency. CI resolves the toolchain from the `go` directive in go.mod (`go-version-file: go.mod` in ci.yaml and release.yaml), so the scan builds against the affected standard library.

Bumps the directive from 1.26.4 to 1.26.5. Verified locally that `govulncheck ./...` reports no vulnerabilities under go1.26.5, and that the build passes with the current dependency set.