### PR TITLE
feat: add --json output to aegisctl verify (#121)

### DIFF
--- a/cmd/aegisctl/main.go
+++ b/cmd/aegisctl/main.go
@@ -261,7 +261,7 @@ func printUsage() {
 Usage: aegisctl <command> [args]
 
 Commands:
-  verify      Verify evidence chain integrity (--session <id> for specific session)
+  verify      Verify evidence chain integrity (--session <id> for specific session, add --json for machine output)
   evidence    Evidence management (sessions, export, report)
   policy-pack Manage policy packs (list, show)
   plugin      Manage WASM plugins (search, info, install, list, outdated, remove)

--- a/cmd/aegisctl/verify.go
+++ b/cmd/aegisctl/verify.go
@@ -10,10 +10,13 @@ import (
 
 func cmdVerify(adminURL string, args []string) {
 	sessionID := ""
+	jsonOut := false
 	for i := 0; i < len(args); i++ {
 		if args[i] == "--session" && i+1 < len(args) {
 			sessionID = args[i+1]
 			i++
+		} else if args[i] == "--json" || args[i] == "-json" {
+			jsonOut = true
 		}
 	}
 
@@ -47,7 +50,20 @@ func cmdVerify(adminURL string, args []string) {
 		os.Exit(1)
 	}
 
-	printVerifyResult(result)
+	if jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetEscapeHTML(false)
+		if err := enc.Encode(result); err != nil {
+			fmt.Fprintf(os.Stderr, "Error encoding JSON: %v\n", err)
+			os.Exit(1)
+		}
+	} else {
+		printVerifyResult(result)
+	}
+
+	if !result.Valid {
+		os.Exit(1)
+	}
 }
 
 // VerifyResponse matches the evidence.VerifyResult JSON structure.

--- a/cmd/aegisctl/verify_test.go
+++ b/cmd/aegisctl/verify_test.go
@@ -1,9 +1,151 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
 	"strings"
 	"testing"
 )
+
+func TestVerifyHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	// Strip test args
+	args := []string{os.Args[0]}
+	for i, arg := range os.Args {
+		if arg == "--" {
+			args = append(args, os.Args[i+1:]...)
+			break
+		}
+	}
+	os.Args = args
+	main()
+	os.Exit(0)
+}
+
+func runVerifyCommand(adminURL string, args ...string) (string, string, int) {
+	cmdArgs := append([]string{"-test.run=TestVerifyHelperProcess", "--", "verify"}, args...)
+	cmd := exec.Command(os.Args[0], cmdArgs...)
+	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1", "AEGISFLOW_ADMIN_URL="+adminURL)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	exitCode := 0
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			exitCode = 1
+		}
+	}
+	return stdout.String(), stderr.String(), exitCode
+}
+
+func TestVerifyJSON_ValidChain(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/admin/v1/audit/verify" {
+			t.Errorf("expected path /admin/v1/audit/verify, got %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"valid": true, "total_records": 10, "message": "all good"}`))
+	}))
+	defer ts.Close()
+
+	stdout, stderr, code := runVerifyCommand(ts.URL, "--json")
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d. stderr: %s", code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %s", stderr)
+	}
+	
+	if strings.Contains(stdout, "\x1b") {
+		t.Fatalf("output must not contain ANSI escapes: %q", stdout)
+	}
+
+	var res VerifyResponse
+	if err := json.Unmarshal([]byte(stdout), &res); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v", err)
+	}
+	if !res.Valid {
+		t.Fatal("expected valid to be true")
+	}
+}
+
+func TestVerifyJSON_InvalidChain(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"valid": false, "total_records": 10, "message": "bad hash"}`))
+	}))
+	defer ts.Close()
+
+	stdout, stderr, code := runVerifyCommand(ts.URL, "--json")
+	if code != 1 {
+		t.Fatalf("expected exit code 1 for invalid chain, got %d", code)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %s", stderr)
+	}
+
+	var res VerifyResponse
+	if err := json.Unmarshal([]byte(stdout), &res); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v (output: %q)", err, stdout)
+	}
+	if res.Valid {
+		t.Fatal("expected valid to be false")
+	}
+}
+
+func TestVerifyJSON_SessionEndpoint(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/admin/v1/evidence/sessions/ses_123/verify" {
+			t.Errorf("expected path /admin/v1/evidence/sessions/ses_123/verify, got %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"valid": true, "total_records": 2, "message": "session valid"}`))
+	}))
+	defer ts.Close()
+
+	stdout, stderr, code := runVerifyCommand(ts.URL, "--session", "ses_123", "--json")
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d. stderr: %s", code, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %s", stderr)
+	}
+
+	var res VerifyResponse
+	if err := json.Unmarshal([]byte(stdout), &res); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v", err)
+	}
+	if !res.Valid {
+		t.Fatal("expected valid to be true")
+	}
+}
+
+func TestVerifyJSON_HTTPError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	stdout, stderr, code := runVerifyCommand(ts.URL, "--json")
+	if code != 1 {
+		t.Fatalf("expected exit code 1 for http error, got %d", code)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %s", stdout)
+	}
+	if !strings.Contains(stderr, "Error (500)") {
+		t.Fatalf("expected Error (500) in stderr, got %s", stderr)
+	}
+}
 
 func TestFormatVerifyResult_Pass(t *testing.T) {
 	r := VerifyResponse{

--- a/cmd/aegisctl/verify_test.go
+++ b/cmd/aegisctl/verify_test.go
@@ -64,7 +64,7 @@ func TestVerifyJSON_ValidChain(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("expected empty stderr, got %s", stderr)
 	}
-	
+
 	if strings.Contains(stdout, "\x1b") {
 		t.Fatalf("output must not contain ANSI escapes: %q", stdout)
 	}


### PR DESCRIPTION
## What does this PR do?
This PR adds a `--json` boolean flag to the `aegisctl verify` command, allowing the verification results to be easily parsed by scripts. 
* When the flag is absent, the existing colored human-readable output is preserved.
* When the flag is present, the API result is emitted strictly as JSON to `stdout`, completely free of ANSI escape codes. 
* Invalid chains print a valid JSON payload (`"valid": false`) to `stdout` and deterministically exit with code `1`.
* Structural and networking errors bypass JSON emission, print to `stderr`, and exit with code `1`.
* Comprehensive tests using a subprocess helper have been added to `verify_test.go` to ensure standard stream routing and exit codes function correctly.

## Related Issue
Closes #121

## Type of Change

- [ ] New provider adapter
- [ ] New policy filter
- [ ] Bug fix
- [x] Enhancement
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing code style
- [x] I have added tests for my changes
- [x] All tests pass (`make test`)
- [x] I have updated documentation if needed