### PR TITLE
feat: add gzip payload compression with zip bomb protection (#16)

### DIFF
--- a/cmd/aegisflow/main.go
+++ b/cmd/aegisflow/main.go
@@ -305,6 +305,7 @@ func main() {
 
 	handler := gateway.NewHandler(registry, rt, pe, ut, responseCache, wh, pgStore, analyticsCollector, cfg.Server.MaxBodySize, recordSpendFn, budgetCheckFn)
 	handler.SetRequestValidation(cfg.Server.RequestValidation)
+	handler.SetCompression(cfg.Server.Compression.Enabled, cfg.Server.Compression.MinSizeBytes)
 	handler.SetRequestLogger(reqLog, cfg.Federation.ControlPlane.Name)
 	handler.SetMessagesToolPassthrough(cfg.MessagesAPI.ToolPassthrough)
 	if semanticCache != nil {

--- a/configs/aegisflow.example.yaml
+++ b/configs/aegisflow.example.yaml
@@ -10,6 +10,9 @@ server:
   write_timeout: 120s           # HTTP write timeout (long for streaming)
   graceful_shutdown: 10s        # Graceful shutdown timeout
   max_body_size: 10485760       # Max request body size in bytes (10MB)
+  compression:
+    enabled: true               # Enable gzip compression
+    min_size_bytes: 1024        # Min response size to compress
 
 # Provider definitions
 # Each provider needs a unique name and a type.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,6 +56,11 @@ type Config struct {
 	keyIndex     map[[32]byte]TenantMatch // sha256(api key) -> tenant/role
 }
 
+type CompressionConfig struct {
+	Enabled      bool `yaml:"enabled"`
+	MinSizeBytes int  `yaml:"min_size_bytes"`
+}
+
 // StateConfig controls local approval and evidence persistence for one process.
 type StateConfig struct {
 	Enabled    bool   `yaml:"enabled"`
@@ -490,15 +495,16 @@ type CostOptConfig struct {
 }
 
 type ServerConfig struct {
-	Host              string        `yaml:"host"`
-	Port              int           `yaml:"port"`
-	AdminPort         int           `yaml:"admin_port"`
-	ReadTimeout       time.Duration `yaml:"read_timeout"`
-	WriteTimeout      time.Duration `yaml:"write_timeout"`
-	GracefulShutdown  time.Duration `yaml:"graceful_shutdown"`
-	MaxBodySize       int64         `yaml:"max_body_size"`
-	CORS              CORSConfig    `yaml:"cors"`
-	RequestValidation bool          `yaml:"request_validation"`
+	Host              string            `yaml:"host"`
+	Port              int               `yaml:"port"`
+	AdminPort         int               `yaml:"admin_port"`
+	ReadTimeout       time.Duration     `yaml:"read_timeout"`
+	WriteTimeout      time.Duration     `yaml:"write_timeout"`
+	GracefulShutdown  time.Duration     `yaml:"graceful_shutdown"`
+	MaxBodySize       int64             `yaml:"max_body_size"`
+	CORS              CORSConfig        `yaml:"cors"`
+	RequestValidation bool              `yaml:"request_validation"`
+	Compression       CompressionConfig `yaml:"compression"`
 }
 
 type CORSConfig struct {

--- a/internal/gateway/anthropic_messages.go
+++ b/internal/gateway/anthropic_messages.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
-	"io"
 	"log"
 	"net/http"
 	"regexp"
@@ -265,8 +264,13 @@ func (h *Handler) Messages(w http.ResponseWriter, r *http.Request) {
 	}
 	r = r.WithContext(context.WithValue(r.Context(), anthropicVersionKey, version))
 
+	bodyBytes, err := readRequestBody(r, h.maxBodySize)
+	if err != nil {
+		writeAnthropicError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
+		return
+	}
 	var in anthropicMessagesRequest
-	if err := json.NewDecoder(io.LimitReader(r.Body, h.maxBodySize)).Decode(&in); err != nil {
+	if err := json.Unmarshal(bodyBytes, &in); err != nil {
 		writeAnthropicError(w, http.StatusBadRequest, "invalid_request_error", "failed to parse request body")
 		return
 	}
@@ -316,7 +320,7 @@ func (h *Handler) Messages(w http.ResponseWriter, r *http.Request) {
 	cachedResp, cacheStatus, semanticEmbedding, hit := h.lookupCache(rc, req)
 	if hit {
 		h.logRequest(startTime, r, tenantID, req.Model, cacheSourceName(cacheStatus), http.StatusOK, cachedResp.Usage.TotalTokens, true, "")
-		writeAnthropicMessage(w, in.Model, cachedResp)
+		h.writeAnthropicMessage(w, r, in.Model, cachedResp)
 		return
 	}
 
@@ -343,12 +347,12 @@ func (h *Handler) Messages(w http.ResponseWriter, r *http.Request) {
 	// usage + analytics + logRequest. Reuses the lookup embedding for the store.
 	h.postResponseGovernance(rc, req, resp, providerName, routed.Region, semanticEmbedding)
 
-	writeAnthropicMessage(w, in.Model, resp)
+	h.writeAnthropicMessage(w, r, in.Model, resp)
 }
 
 // writeAnthropicMessage serializes an internal ChatCompletionResponse as an
 // Anthropic Messages envelope. Shared by the live and cache-hit response paths.
-func writeAnthropicMessage(w http.ResponseWriter, model string, resp *types.ChatCompletionResponse) {
+func (h *Handler) writeAnthropicMessage(w http.ResponseWriter, r *http.Request, model string, resp *types.ChatCompletionResponse) {
 	content := ""
 	finishReason := ""
 	var toolCalls []types.ToolCall
@@ -390,7 +394,7 @@ func writeAnthropicMessage(w http.ResponseWriter, model string, resp *types.Chat
 		},
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(out)
+	h.encodeResponse(w, r, out)
 }
 
 // CountTokens handles POST /v1/messages/count_tokens. The Anthropic SDK and
@@ -398,8 +402,13 @@ func writeAnthropicMessage(w http.ResponseWriter, model string, resp *types.Chat
 // upstream tokenizer, so it returns a byte-based estimate; the value is
 // advisory. Response shape: {"input_tokens": N}.
 func (h *Handler) CountTokens(w http.ResponseWriter, r *http.Request) {
+	bodyBytes, err := readRequestBody(r, h.maxBodySize)
+	if err != nil {
+		writeAnthropicError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
+		return
+	}
 	var in anthropicMessagesRequest
-	if err := json.NewDecoder(io.LimitReader(r.Body, h.maxBodySize)).Decode(&in); err != nil {
+	if err := json.Unmarshal(bodyBytes, &in); err != nil {
 		writeAnthropicError(w, http.StatusBadRequest, "invalid_request_error", "failed to parse request body")
 		return
 	}
@@ -410,7 +419,7 @@ func (h *Handler) CountTokens(w http.ResponseWriter, r *http.Request) {
 	req := translateMessagesRequest(&in, false)
 	tokens := estimateTokens(extractContent(req.Messages))
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]int{"input_tokens": tokens})
+	h.encodeResponse(w, r, map[string]int{"input_tokens": tokens})
 }
 
 // writeSSE writes one Anthropic SSE event (named event + JSON data) and flushes.

--- a/internal/gateway/anthropic_tools_test.go
+++ b/internal/gateway/anthropic_tools_test.go
@@ -95,7 +95,9 @@ func TestWriteAnthropicMessage_EmitsToolUse(t *testing.T) {
 		}},
 		Usage: types.Usage{PromptTokens: 5, CompletionTokens: 3},
 	}
-	writeAnthropicMessage(w, "claude-x", resp)
+	h := setupTestHandler()
+	r := httptest.NewRequest(http.MethodPost, "/", nil)
+	h.writeAnthropicMessage(w, r, "claude-x", resp)
 
 	var out anthropicMessagesResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
@@ -124,7 +126,9 @@ func TestWriteAnthropicMessage_TextOnly(t *testing.T) {
 	resp := &types.ChatCompletionResponse{
 		Choices: []types.Choice{{FinishReason: "stop", Message: types.Message{Role: "assistant", Content: "hi there"}}},
 	}
-	writeAnthropicMessage(w, "claude-x", resp)
+	h := setupTestHandler()
+	r := httptest.NewRequest(http.MethodPost, "/", nil)
+	h.writeAnthropicMessage(w, r, "claude-x", resp)
 	var out anthropicMessagesResponse
 	json.Unmarshal(w.Body.Bytes(), &out)
 	if out.StopReason != "end_turn" {

--- a/internal/gateway/gzip_test.go
+++ b/internal/gateway/gzip_test.go
@@ -1,0 +1,245 @@
+package gateway
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/saivedant169/AegisFlow/pkg/types"
+)
+
+func TestGzipDecodingValid(t *testing.T) {
+	h := setupTestHandler() // from handler_test.go
+	h.maxBodySize = 1024 * 1024
+
+	reqBody := types.ChatCompletionRequest{
+		Model:    "mock",
+		Messages: []types.Message{{Role: "user", Content: "Hello"}},
+	}
+	body, _ := json.Marshal(reqBody)
+
+	var b bytes.Buffer
+	w := gzip.NewWriter(&b)
+	w.Write(body)
+	w.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", &b)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Encoding", "gzip")
+	rw := httptest.NewRecorder()
+
+	h.ChatCompletion(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rw.Code)
+	}
+}
+
+func TestGzipDecodingInvalid(t *testing.T) {
+	h := setupTestHandler()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader([]byte("not a gzip")))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Encoding", "gzip")
+	rw := httptest.NewRecorder()
+
+	h.ChatCompletion(rw, req)
+
+	if rw.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for invalid gzip, got %d", rw.Code)
+	}
+}
+
+func TestGzipDecodingZipBomb(t *testing.T) {
+	h := setupTestHandler()
+	h.maxBodySize = 100 // strict limit for test
+
+	// Create a payload that compresses to very small but decompresses to > 100 bytes
+	largeString := strings.Repeat("a", 200)
+	reqBody := types.ChatCompletionRequest{
+		Model:    "mock",
+		Messages: []types.Message{{Role: "user", Content: largeString}},
+	}
+	body, _ := json.Marshal(reqBody)
+
+	var b bytes.Buffer
+	w := gzip.NewWriter(&b)
+	w.Write(body)
+	w.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", &b)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Encoding", "gzip")
+	rw := httptest.NewRecorder()
+
+	h.ChatCompletion(rw, req)
+
+	if rw.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for zip bomb exceeding maxBodySize, got %d", rw.Code)
+	}
+	respStr := rw.Body.String()
+	if !strings.Contains(respStr, "request body too large") {
+		t.Errorf("expected body too large error, got %s", respStr)
+	}
+}
+
+func TestGzipEncoding(t *testing.T) {
+	h := setupTestHandler()
+	h.SetCompression(true, 50) // enable, threshold 50 bytes
+
+	reqBody := types.ChatCompletionRequest{
+		Model:    "mock",
+		Messages: []types.Message{{Role: "user", Content: "Hello world this is a test"}}, // should produce > 50 bytes response
+	}
+	body, _ := json.Marshal(reqBody)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept-Encoding", "gzip")
+	rw := httptest.NewRecorder()
+
+	h.ChatCompletion(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rw.Code)
+	}
+
+	if rw.Header().Get("Content-Encoding") != "gzip" {
+		t.Errorf("expected Content-Encoding: gzip, got %q", rw.Header().Get("Content-Encoding"))
+	}
+	if rw.Header().Get("Vary") != "Accept-Encoding" {
+		t.Errorf("expected Vary: Accept-Encoding, got %q", rw.Header().Get("Vary"))
+	}
+
+	gr, err := gzip.NewReader(rw.Body)
+	if err != nil {
+		t.Fatalf("failed to read gzip response: %v", err)
+	}
+	defer gr.Close()
+	decompressed, _ := io.ReadAll(gr)
+
+	var resp types.ChatCompletionResponse
+	if err := json.Unmarshal(decompressed, &resp); err != nil {
+		t.Fatalf("failed to unmarshal decompressed response: %v", err)
+	}
+	if len(resp.Choices) != 1 {
+		t.Errorf("expected 1 choice, got %d", len(resp.Choices))
+	}
+}
+
+func TestGzipEncodingDisabled(t *testing.T) {
+	h := setupTestHandler()
+	h.SetCompression(false, 10) // disabled
+
+	reqBody := types.ChatCompletionRequest{
+		Model:    "mock",
+		Messages: []types.Message{{Role: "user", Content: "Hello"}},
+	}
+	body, _ := json.Marshal(reqBody)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept-Encoding", "gzip")
+	rw := httptest.NewRecorder()
+
+	h.ChatCompletion(rw, req)
+
+	if rw.Header().Get("Content-Encoding") == "gzip" {
+		t.Error("expected no gzip encoding when disabled")
+	}
+}
+
+func TestGzipEncodingBelowThreshold(t *testing.T) {
+	h := setupTestHandler()
+	h.SetCompression(true, 10000) // high threshold
+
+	reqBody := types.ChatCompletionRequest{
+		Model:    "mock",
+		Messages: []types.Message{{Role: "user", Content: "Hello"}},
+	}
+	body, _ := json.Marshal(reqBody)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept-Encoding", "gzip")
+	rw := httptest.NewRecorder()
+
+	h.ChatCompletion(rw, req)
+
+	if rw.Header().Get("Content-Encoding") == "gzip" {
+		t.Error("expected no gzip encoding when response is below threshold")
+	}
+}
+
+func TestGzipEncodingStream(t *testing.T) {
+	h := setupTestHandler()
+	h.SetCompression(true, 10)
+
+	reqBody := types.ChatCompletionRequest{
+		Model:    "mock",
+		Messages: []types.Message{{Role: "user", Content: "Hello"}},
+		Stream:   true,
+	}
+	body, _ := json.Marshal(reqBody)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept-Encoding", "gzip")
+	rw := httptest.NewRecorder()
+
+	h.ChatCompletion(rw, req)
+
+	if rw.Header().Get("Content-Encoding") == "gzip" {
+		t.Error("expected no gzip encoding for streams")
+	}
+}
+
+func BenchmarkGzipEncoding(b *testing.B) {
+	h := setupTestHandler()
+	h.SetCompression(true, 50)
+
+	reqBody := types.ChatCompletionRequest{
+		Model:    "mock",
+		Messages: []types.Message{{Role: "user", Content: "Hello benchmark testing"}},
+	}
+	body, _ := json.Marshal(reqBody)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept-Encoding", "gzip")
+		rw := httptest.NewRecorder()
+		h.ChatCompletion(rw, req)
+	}
+}
+
+func BenchmarkGzipDecoding(b *testing.B) {
+	h := setupTestHandler()
+	h.maxBodySize = 10 * 1024 * 1024
+
+	reqBody := types.ChatCompletionRequest{
+		Model:    "mock",
+		Messages: []types.Message{{Role: "user", Content: "Hello benchmark testing"}},
+	}
+	body, _ := json.Marshal(reqBody)
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	w.Write(body)
+	w.Close()
+	gzBody := buf.Bytes()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(gzBody))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Content-Encoding", "gzip")
+		rw := httptest.NewRecorder()
+		h.ChatCompletion(rw, req)
+	}
+}

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"compress/gzip"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -202,28 +203,34 @@ func (h *Handler) SetEval(builtinEnabled bool, minTokens int, latencyMul float64
 	h.evalWebhook = webhook
 }
 
-func (h *Handler) ChatCompletion(w http.ResponseWriter, r *http.Request) {
-	startTime := time.Now()
-
+func readRequestBody(r *http.Request, maxBodySize int64) ([]byte, error) {
 	var bodyReader io.Reader = r.Body
 	if strings.Contains(r.Header.Get("Content-Encoding"), "gzip") {
 		gr, err := gzip.NewReader(r.Body)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, "invalid_request", "invalid gzip body")
-			return
+			return nil, fmt.Errorf("invalid gzip body: %w", err)
 		}
 		defer gr.Close()
 		bodyReader = gr
 	}
 
-	limitReader := io.LimitReader(bodyReader, h.maxBodySize+1)
+	limitReader := io.LimitReader(bodyReader, maxBodySize+1)
 	bodyBytes, err := io.ReadAll(limitReader)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_request", "failed to read request body")
-		return
+		return nil, fmt.Errorf("failed to read request body: %w", err)
 	}
-	if int64(len(bodyBytes)) > h.maxBodySize {
-		writeError(w, http.StatusBadRequest, "invalid_request", "request body too large")
+	if int64(len(bodyBytes)) > maxBodySize {
+		return nil, fmt.Errorf("request body too large")
+	}
+	return bodyBytes, nil
+}
+
+func (h *Handler) ChatCompletion(w http.ResponseWriter, r *http.Request) {
+	startTime := time.Now()
+
+	bodyBytes, err := readRequestBody(r, h.maxBodySize)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
 		return
 	}
 
@@ -308,8 +315,12 @@ func (h *Handler) encodeResponse(w http.ResponseWriter, r *http.Request, resp an
 		w.Header().Set("Content-Encoding", "gzip")
 		w.Header().Set("Vary", "Accept-Encoding")
 		gw := gzip.NewWriter(w)
-		defer gw.Close()
-		gw.Write(respBytes)
+		if _, err := gw.Write(respBytes); err != nil {
+			log.Printf("encodeResponse: failed to write gzip body: %v", err)
+		}
+		if err := gw.Close(); err != nil {
+			log.Printf("encodeResponse: failed to close gzip writer: %v", err)
+		}
 	} else {
 		w.Write(respBytes)
 	}

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"compress/gzip"
 	"encoding/json"
 	"io"
 	"log"
@@ -56,11 +57,19 @@ type Handler struct {
 	behavioralRegistry   *behavioral.Registry
 	messagesToolsEnabled bool
 	requestValidation    bool
+	compressionEnabled   bool
+	compressionMinBytes  int
 }
 
 // SetRequestValidation configures whether schema validation is enforced on incoming requests.
 func (h *Handler) SetRequestValidation(enabled bool) {
 	h.requestValidation = enabled
+}
+
+// SetCompression configures payload compression.
+func (h *Handler) SetCompression(enabled bool, minSizeBytes int) {
+	h.compressionEnabled = enabled
+	h.compressionMinBytes = minSizeBytes
 }
 
 // SetMessagesToolPassthrough enables tool translation on the /v1/messages
@@ -196,9 +205,25 @@ func (h *Handler) SetEval(builtinEnabled bool, minTokens int, latencyMul float64
 func (h *Handler) ChatCompletion(w http.ResponseWriter, r *http.Request) {
 	startTime := time.Now()
 
-	bodyBytes, err := io.ReadAll(io.LimitReader(r.Body, h.maxBodySize))
+	var bodyReader io.Reader = r.Body
+	if strings.Contains(r.Header.Get("Content-Encoding"), "gzip") {
+		gr, err := gzip.NewReader(r.Body)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", "invalid gzip body")
+			return
+		}
+		defer gr.Close()
+		bodyReader = gr
+	}
+
+	limitReader := io.LimitReader(bodyReader, h.maxBodySize+1)
+	bodyBytes, err := io.ReadAll(limitReader)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "invalid_request", "failed to read request body")
+		return
+	}
+	if int64(len(bodyBytes)) > h.maxBodySize {
+		writeError(w, http.StatusBadRequest, "invalid_request", "request body too large")
 		return
 	}
 
@@ -241,7 +266,7 @@ func (h *Handler) ChatCompletion(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("X-AegisFlow-Cache", cacheStatus)
 		h.logRequest(startTime, r, tenantID, req.Model, cacheSourceName(cacheStatus), http.StatusOK, cachedResp.Usage.TotalTokens, true, "")
-		json.NewEncoder(w).Encode(cachedResp)
+		h.encodeResponse(w, r, cachedResp)
 		return
 	}
 
@@ -269,7 +294,25 @@ func (h *Handler) ChatCompletion(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("X-AegisFlow-Cache", "MISS")
-	json.NewEncoder(w).Encode(resp)
+	h.encodeResponse(w, r, resp)
+}
+
+func (h *Handler) encodeResponse(w http.ResponseWriter, r *http.Request, resp any) {
+	respBytes, err := json.Marshal(resp)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "server_error", "failed to marshal response")
+		return
+	}
+
+	if h.compressionEnabled && len(respBytes) >= h.compressionMinBytes && strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Set("Vary", "Accept-Encoding")
+		gw := gzip.NewWriter(w)
+		defer gw.Close()
+		gw.Write(respBytes)
+	} else {
+		w.Write(respBytes)
+	}
 }
 
 func (h *Handler) handleStream(w http.ResponseWriter, rc requestContext, req *types.ChatCompletionRequest) {


### PR DESCRIPTION
## What does this PR do?
This PR introduces request and response payload compression (gzip) for the gateway, fulfilling the requirements of #16 and ensuring strict safety and streaming constraints are met.

* **Configuration:** Added a `compression` config block to `ServerConfig` (`enabled` and `min_size_bytes`).
* **Request Decoding & Safety (Zip Bomb Prevention):** Gzip request bodies are now transparently decompressed. Crucially, `io.LimitReader` is applied to the *decompressed* stream using the existing `MaxBodySize` limit to safely prevent memory exhaustion from highly compressed malicious payloads.
* **Response Encoding:** Non-streaming JSON responses are conditionally compressed if compression is enabled, the payload meets the `min_size_bytes` threshold, and the client sends `Accept-Encoding: gzip`. Headers (`Content-Encoding`, `Vary`) are set automatically.
* **Streaming Preservation:** Streaming and SSE responses bypass the compression path entirely, ensuring unbuffered flush behavior works identically to before.
* **Testing & Benchmarks:** Added comprehensive tests for valid/invalid payloads, threshold boundaries, stream exclusion, and zip bomb prevention. Focused benchmarks are included for both encoding and decoding paths.

## Related Issue
Closes #16

## Type of Change

- [ ] New provider adapter
- [ ] New policy filter
- [ ] Bug fix
- [x] Enhancement
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the existing code style
- [x] I have added tests for my changes
- [x] All tests pass (`make test`)
- [ ] I have updated documentation if needed